### PR TITLE
changes to tackle issue #12: deal with cloud point data 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ log*
 *.toc
 *.dot
 core
+.idea

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -181,7 +181,7 @@ class InversionCfg(ConfigPrinter):
         """
         Check consistency of inversion parameters.
         """
-        assert (self.alpha_active or self.beta_active or self.use_cloud_point_velocities)
+        assert (self.alpha_active or self.beta_active)
 
         assert self.initial_guess_alpha_method.lower() in ["sia", "wearing", "constant"]
 

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -173,13 +173,15 @@ class InversionCfg(ConfigPrinter):
     initial_guess_alpha: float = None
     initial_guess_alpha_method: str = "sia"
 
+    use_cloud_point_velocities: bool = False
+
     mass_precon: bool = True
 
     def __post_init__(self):
         """
         Check consistency of inversion parameters.
         """
-        assert (self.alpha_active or self.beta_active)
+        assert (self.alpha_active or self.beta_active or self.use_cloud_point_velocities)
 
         assert self.initial_guess_alpha_method.lower() in ["sia", "wearing", "constant"]
 

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -376,21 +376,15 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
 
     #Test that when we read a cloud point data file we have less data
     # than the composite
-    keys = list(out.keys())
-    sizes_pts=[]
-    sizes=[]
-    for key in keys:
-        if '_pts' in key:
-            sizes_pts = np.append(sizes_pts, out[key][0].size)
-        else:
-            sizes=np.append(sizes, out[key][0].size)
+    sizes_pts = np.array([out[key][0].size for key in filter(lambda key: "_pts" in key, out)])
+    sizes = np.array([out[key][0].size for key in filter(lambda key: "_pts" not in key, out)])
     if use_cloud_point:
         assert sizes_pts[0] < sizes_pts[-1]
         assert np.all(sizes[0:4] == sizes[0])
         assert np.all(sizes[4:-1] == sizes[-1])
     else:
         assert sizes_pts[0] == sizes_pts[-1]
-        assert np.all(sizes)
+        assert np.all(sizes == sizes[0])
 
     if model is not None:
         model.vel_obs = out

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -324,15 +324,6 @@ def read_vel_obs(params, model=None):
 
     infile = h5py.File(infile, 'r')
 
-    # Read cloud point observations to be used in the Inversion and
-    # Cost function optimization only!
-    x_obs = field_from_vel_file(infile, 'x')
-    y_obs = field_from_vel_file(infile, 'y')
-    u_obs = field_from_vel_file(infile, 'u_obs')
-    v_obs = field_from_vel_file(infile, 'v_obs')
-    u_std = field_from_vel_file(infile, 'u_std')
-    v_std = field_from_vel_file(infile, 'v_std')
-
     # Read composite mean of velocity
     # components and uncertainty to calculate
     # initial alpha and define boundary conditions
@@ -344,6 +335,25 @@ def read_vel_obs(params, model=None):
     v_comp = field_from_vel_file(infile, 'v_comp')
     u_comp_std = field_from_vel_file(infile, 'u_comp_std')
     v_comp_std = field_from_vel_file(infile, 'v_comp_std')
+
+    if params.inversion.use_cloud_point_velocities:
+        logging.warning(f"You are using cloud point data for optimizing J, "
+                        f"inversion results might not be smooth")
+        # Read cloud point observations to be used in the Inversion and
+        # Cost function optimization only!
+        x_obs = field_from_vel_file(infile, 'x')
+        y_obs = field_from_vel_file(infile, 'y')
+        u_obs = field_from_vel_file(infile, 'u_obs')
+        v_obs = field_from_vel_file(infile, 'v_obs')
+        u_std = field_from_vel_file(infile, 'u_std')
+        v_std = field_from_vel_file(infile, 'v_std')
+    else:
+        x_obs = x_comp
+        y_obs = y_comp
+        u_obs = u_comp
+        v_obs = v_comp
+        u_std = u_comp_std
+        v_std = v_comp_std
 
     assert x_obs.size == y_obs.size == u_obs.size == v_obs.size
     assert v_obs.size == u_std.size == v_std.size

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -323,30 +323,37 @@ def read_vel_obs(params, model=None):
     assert infile.exists(), f"Couldn't find velocity observations file: {infile}"
 
     infile = h5py.File(infile, 'r')
+    keys = list(infile.keys())
 
-    # Read composite mean of velocity
-    # components and uncertainty to calculate
-    # initial alpha and define boundary conditions
-    mask_vel = field_from_vel_file(infile, 'mask_vel_comp')
+    assert 'u_obs' in keys, \
+        f"Your vel file has not been configure correctly " \
+        f"make sure you have velocity data with the correct var names " \
+        f"x, y, u_obs, v_obs, u_obs_std, v_obs_std "
 
-    x_comp = field_from_vel_file(infile, 'x_comp')
-    y_comp = field_from_vel_file(infile, 'y_comp')
-    u_comp = field_from_vel_file(infile, 'u_comp')
-    v_comp = field_from_vel_file(infile, 'v_comp')
-    u_comp_std = field_from_vel_file(infile, 'u_comp_std')
-    v_comp_std = field_from_vel_file(infile, 'v_comp_std')
+    # Read composite mean of velocity data as default
+    mask_vel = field_from_vel_file(infile, 'mask_vel')
+    x_comp = field_from_vel_file(infile, 'x')
+    y_comp = field_from_vel_file(infile, 'y')
+    u_comp = field_from_vel_file(infile, 'u_obs')
+    v_comp = field_from_vel_file(infile, 'v_obs')
+    u_comp_std = field_from_vel_file(infile, 'u_std')
+    v_comp_std = field_from_vel_file(infile, 'v_std')
 
     if params.inversion.use_cloud_point_velocities:
         logging.warning(f"You are using cloud point data for optimizing J, "
                         f"inversion results might not be smooth")
+        assert 'u_cloud' in keys, \
+            f"Your vel file has not been configure correctly " \
+            f"make sure you have cloud point data with the correct var names " \
+            f"x_cloud, y_cloud, u_cloud, v_cloud, u_cloud_std, v_cloud_std"
         # Read cloud point observations to be used in the Inversion and
         # Cost function optimization only!
-        x_obs = field_from_vel_file(infile, 'x')
-        y_obs = field_from_vel_file(infile, 'y')
-        u_obs = field_from_vel_file(infile, 'u_obs')
-        v_obs = field_from_vel_file(infile, 'v_obs')
-        u_std = field_from_vel_file(infile, 'u_std')
-        v_std = field_from_vel_file(infile, 'v_std')
+        x_obs = field_from_vel_file(infile, 'x_cloud')
+        y_obs = field_from_vel_file(infile, 'y_cloud')
+        u_obs = field_from_vel_file(infile, 'u_cloud')
+        v_obs = field_from_vel_file(infile, 'v_cloud')
+        u_std = field_from_vel_file(infile, 'u_cloud_std')
+        v_std = field_from_vel_file(infile, 'v_cloud_std')
     else:
         x_obs = x_comp
         y_obs = y_comp
@@ -376,7 +383,8 @@ def read_vel_obs(params, model=None):
         model.v_comp_std = v_comp_std
         model.mask_vel = mask_vel
     else:
-        return uv_obs_pts, u_obs, v_obs, u_std, v_std, mask_vel, uv_comp_pts, u_comp, v_comp, u_comp_std, v_comp_std
+        return uv_obs_pts, u_obs, v_obs, u_std, v_std, mask_vel, \
+               uv_comp_pts, u_comp, v_comp, u_comp_std, v_comp_std
 
 class DataNotFound(Exception):
     """Custom exception for unfound data"""

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -31,7 +31,6 @@ import netCDF4
 import git
 from scipy import interpolate as interp
 from abc import ABC, abstractmethod
-from collections import defaultdict
 
 from fenics import *
 from tlm_adjoint.fenics import configure_checkpointing
@@ -361,23 +360,22 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
     uv_cloud_pts = np.vstack((x_cloud, y_cloud)).T
     uv_obs_pts = np.vstack((x, y)).T
 
-    out = defaultdict(list)
-    out['uv_obs_pts'].append(uv_cloud_pts)
-    out['u_obs'].append(u_cloud)
-    out['v_obs'].append(v_cloud)
-    out['u_std'].append(u_cloud_std)
-    out['v_std'].append(v_cloud_std)
-    out['uv_comp_pts'].append(uv_obs_pts)
-    out['u_comp'].append(u_obs)
-    out['v_comp'].append(v_obs)
-    out['u_comp_std'].append(u_std)
-    out['v_comp_std'].append(v_std)
-    out['mask_vel'].append(mask_vel)
+    out = {'uv_obs_pts': uv_cloud_pts,
+           'u_obs': u_cloud,
+           'v_obs': v_cloud,
+           'u_std': u_cloud_std,
+           'v_std': v_cloud_std,
+           'uv_comp_pts': uv_obs_pts,
+           'u_comp': u_obs,
+           'v_comp': v_obs,
+           'u_comp_std': u_std,
+           'v_comp_std': v_std,
+           'mask_vel': mask_vel}
 
     #Test that when we read a cloud point data file we have less data
     # than the composite
-    sizes_pts = np.array([out[key][0].size for key in filter(lambda key: "_pts" in key, out)])
-    sizes = np.array([out[key][0].size for key in filter(lambda key: "_pts" not in key, out)])
+    sizes_pts = np.array([out[key].size for key in filter(lambda key: "_pts" in key, out)])
+    sizes = np.array([out[key].size for key in filter(lambda key: "_pts" not in key, out)])
     if use_cloud_point:
         assert sizes_pts[0] < sizes_pts[-1]
         assert np.all(sizes[0:4] == sizes[0])

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -309,16 +309,24 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
     """
     Reads velocity observations & uncertainty from a HDF5 file
     containing:
-    - point cloud velocities (u_obs, v_obs) for inversion only
+    - point cloud velocities (u_obs, v_obs) to compute the value
+        of the cost function only and only used if use_cloud_point=True.
     - gridded data set of composite ice velocities & uncertainties
-    use for alpha initialisation and boundary conditions
+        use for alpha initialisation and boundary conditions even
+        if point cloud data is given. And also use to compute the value
+        of the cost function as default.
     All variables in the HDF5 file should be with the form
     (values, )
 
-    Generates self.u_obs, self.v_obs, self.u_std, self.v_std,
-    self.uv_obs_pts, self.mask_vel
-    self.u_comp, self.v_comp, self.u_comp_std, self.v_comp_std,
-    self.uv_comp_pts
+    Params:
+    -------
+    infile: path to .h5 path
+    model: fenics_ice model object
+    use_cloud_point: bool
+    Returns:
+    --------
+    model.vel_obs: as a python directory with the velocity data
+    out: python directory if model=None
     """
     assert infile.exists(), f"Couldn't find velocity observations file: {infile}"
 

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -34,6 +34,7 @@ from abc import ABC, abstractmethod
 
 from fenics import *
 from tlm_adjoint.fenics import configure_checkpointing
+from collections import defaultdict
 import numpy as np
 
 # Regex for catching unnamed vars
@@ -315,6 +316,16 @@ def read_vel_obs(params, model=None):
 
     infile = h5py.File(infile, 'r')
 
+    # Get grid extent for interpolate via griddata in model.py
+    list_extend = list(infile.attrs.keys())
+    assert len(list_extend) > 0, \
+        f"Invalid velocity file, you need to " \
+        f"specify grid extend and spacing for file {infile}"
+
+    extend = defaultdict(list)
+    for item in list_extend:
+        extend[item].append(infile.attrs[item])
+
     x_obs = field_from_vel_file(infile, 'x')
     y_obs = field_from_vel_file(infile, 'y')
     u_obs = field_from_vel_file(infile, 'u_obs')
@@ -335,8 +346,9 @@ def read_vel_obs(params, model=None):
         model.u_std = u_std
         model.v_std = v_std
         model.mask_vel = mask_vel
+        model.extend = extend
     else:
-        return uv_obs_pts, u_obs, v_obs, u_std, v_std, mask_vel
+        return uv_obs_pts, u_obs, v_obs, u_std, v_std, mask_vel, extend
 
 class DataNotFound(Exception):
     """Custom exception for unfound data"""

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -305,7 +305,7 @@ def field_from_vel_file(infile, field_name):
 
     return np.ravel(field[:])
 
-def read_vel_obs(infile, use_cloud_point=False, model=None):
+def read_vel_obs(infile, model=None, use_cloud_point=False):
     """
     Reads velocity observations & uncertainty from a HDF5 file
     containing:

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -34,7 +34,6 @@ from abc import ABC, abstractmethod
 
 from fenics import *
 from tlm_adjoint.fenics import configure_checkpointing
-from collections import defaultdict
 import numpy as np
 
 # Regex for catching unnamed vars
@@ -307,9 +306,11 @@ def field_from_vel_file(infile, field_name):
 
 def read_vel_obs(params, model=None):
     """
-    Read velocity observations & uncertainty as point cloud
-    data with no nans and composite ice velocities & uncertainty
-    (gridded data set with no nans) from HDF5 file.
+    Reads velocity observations & uncertainty from a HDF5 file
+    containing:
+    - point cloud velocities (u_obs, v_obs) for inversion only
+    - gridded data set of composite ice velocities & uncertainties
+    use for alpha initialisation and boundary conditions
     All variables in the HDF5 file should be with the form
     (values, )
 

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -353,10 +353,6 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
     uv_cloud_pts = np.vstack((x_cloud, y_cloud)).T
     uv_obs_pts = np.vstack((x, y)).T
 
-    # assert x_cloud.size == y_cloud.size == u_cloud.size == v_cloud.size
-    # assert v_cloud.size == u_cloud_std.size == v_cloud_std.size
-    # assert x.size == y.size == u_obs.size == v_obs.size
-    # assert v_obs.size == u_std.size == v_std.size == mask_vel.size
     out = defaultdict(list)
     out['uv_obs_pts'].append(uv_cloud_pts)
     out['u_obs'].append(u_cloud)

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -252,9 +252,9 @@ class model:
         Q_coords = self.Q.tabulate_dof_coordinates()
         M_coords = self.M.tabulate_dof_coordinates()
 
-        vtx_Q, wts_Q = interp_weights(self.vel_obs['uv_comp_pts'][0],
+        vtx_Q, wts_Q = interp_weights(self.vel_obs['uv_comp_pts'],
                                       Q_coords)
-        vtx_M, wts_M = interp_weights(self.vel_obs['uv_comp_pts'][0],
+        vtx_M, wts_M = interp_weights(self.vel_obs['uv_comp_pts'],
                                       M_coords)
 
         # Define new functions to hold results
@@ -271,19 +271,19 @@ class model:
         self.mask_vel_M = Function(self.M, name="mask_vel", static=True)
 
         # Fill via interpolation
-        self.u_obs_Q.vector()[:] = interpolate(self.vel_obs['u_comp'][0], vtx_Q, wts_Q)
-        self.v_obs_Q.vector()[:] = interpolate(self.vel_obs['v_comp'][0], vtx_Q, wts_Q)
-        self.u_std_Q.vector()[:] = interpolate(self.vel_obs['u_comp_std'][0], vtx_Q, wts_Q)
-        self.v_std_Q.vector()[:] = interpolate(self.vel_obs['v_comp_std'][0], vtx_Q, wts_Q)
+        self.u_obs_Q.vector()[:] = interpolate(self.vel_obs['u_comp'], vtx_Q, wts_Q)
+        self.v_obs_Q.vector()[:] = interpolate(self.vel_obs['v_comp'], vtx_Q, wts_Q)
+        self.u_std_Q.vector()[:] = interpolate(self.vel_obs['u_comp_std'], vtx_Q, wts_Q)
+        self.v_std_Q.vector()[:] = interpolate(self.vel_obs['v_comp_std'], vtx_Q, wts_Q)
         # self.mask_vel_Q.vector()[:] = interpolate(self.mask_vel, vtx_Q, wts_Q)
 
-        self.u_obs_M.vector()[:] = interpolate(self.vel_obs['u_comp'][0], vtx_M, wts_M)
-        self.v_obs_M.vector()[:] = interpolate(self.vel_obs['v_comp'][0], vtx_M, wts_M)
+        self.u_obs_M.vector()[:] = interpolate(self.vel_obs['u_comp'], vtx_M, wts_M)
+        self.v_obs_M.vector()[:] = interpolate(self.vel_obs['v_comp'], vtx_M, wts_M)
         # self.u_std_M.vector()[:] = interpolate(self.u_std, vtx_M, wts_M)
         # self.v_std_M.vector()[:] = interpolate(self.v_std, vtx_M, wts_M)
         # IMPORTANT! this mask is not the vel mask of cloud point observations
         # it is the mask from the composite velocities
-        self.mask_vel_M.vector()[:] = interpolate(self.vel_obs['mask_vel'][0], vtx_M, wts_M)
+        self.mask_vel_M.vector()[:] = interpolate(self.vel_obs['mask_vel'], vtx_M, wts_M)
 
     def init_vel_obs_old(self, u, v, mv, ustd=Constant(1.0),
                          vstd=Constant(1.0), ls=False):

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -26,7 +26,6 @@ from fenics_ice import inout, prior
 from fenics_ice import mesh as fice_mesh
 from numpy.random import randn
 import logging
-from IPython import embed
 
 log = logging.getLogger("fenics_ice")
 
@@ -206,15 +205,13 @@ class model:
         # Generates self.u_obs, self.v_obs, self.u_std, self.v_std,
         # self.uv_obs_pts, self.mask_vel
         inout.read_vel_obs(self.params, self)
-        print('we start ---- ')
-        embed()
+
         # Functions for repeated ungridded interpolation
         # TODO - this will not handle extrapolation/missing data
         # nicely - unfound simplex are returned '-1' which takes the last
         # tri.simplices...
         def interp_weights(xy, uv, d=2):
             """Compute the nearest vertices & weights (for reuse)"""
-            print('weight interpolation starts ----')
             tri = qhull.Delaunay(xy)
             simplex = tri.find_simplex(uv)
 
@@ -312,8 +309,6 @@ class model:
         # self.u_std_M.vector()[:] = interpolate(self.u_std, vtx_M, wts_M)
         # self.v_std_M.vector()[:] = interpolate(self.v_std, vtx_M, wts_M)
         self.mask_vel_M.vector()[:] = interpolate(self.mask_vel_int, vtx_M, wts_M)
-        embed()
-        print('vel function finished ----')
 
     def init_vel_obs_old(self, u, v, mv, ustd=Constant(1.0),
                          vstd=Constant(1.0), ls=False):

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -195,22 +195,22 @@ class model:
 
     def vel_obs_from_data(self):
         """
-        Reads ice velocity observations (point cloud data)
-        and composite ice velocities (with no nans or missing data)
-        from HDF5 file.
+        Reads ice velocity observations from HDF5 file.
         - Additionally interpolates composite velocities
-        (gridded spaced data) onto self.Q for use as boundary
-        conditions and alpha initialisation.
-        - Velocities in a cloud point format are kept for inversion
-        only.
+            (gridded spaced data) to mesh coordinates
+            to be use in setting the boundary conditions
+            and alpha initialisation.
+        - Velocities in a cloud point format are kept to compute
+            the value of the cost function only if
+            params.inversion.use_cloud_point_velocities = true
+            else we use composite velocities
 
         Expects an HDF5 file with the following list of variables
-        in a tuple format e.g. x -> (values, )
-        Generates:
-        self.u_obs, self.v_obs, self.u_std, self.v_std,
-        self.uv_obs_pts, self.mask_vel
-        self.u_comp, self.v_comp, self.u_comp_std, self.v_comp_std,
-        self.uv_comp_pts.
+            u_obs, v_obs, u_std, v_std, mask_vel, x, y (as default)
+            and if params.inversion.use_cloud_point_velocities = true
+        expects the variables above plus cloud point data with the name:
+            u_cloud, v_cloud, u_cloud_std, v_cloud_std, x_could, y_could
+        Everything without nan's and in a tuple format e.g. x -> (values, )
         """
         infile = Path(self.params.io.input_dir) / self.params.obs.vel_file
         if self.params.inversion.use_cloud_point_velocities:

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -215,10 +215,10 @@ class model:
         infile = Path(self.params.io.input_dir) / self.params.obs.vel_file
         if self.params.inversion.use_cloud_point_velocities:
             inout.read_vel_obs(infile,
-                               self,
-                               self.params.inversion.use_cloud_point_velocities)
+                               model=self,
+                               use_cloud_point=self.params.inversion.use_cloud_point_velocities)
         else:
-            inout.read_vel_obs(infile, self)
+            inout.read_vel_obs(infile, model=self)
         # Functions for repeated ungridded interpolation
         # TODO - this will not handle extrapolation/missing data
         # nicely - unfound simplex are returned '-1' which takes the last

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -40,6 +40,7 @@ class model:
                  init_vel_obs=True):
 
         # Initiate parameters
+        self.vel_obs = None
         self.params = param_in
         self.input_data = input_data
         self.solvers = []
@@ -211,8 +212,13 @@ class model:
         self.u_comp, self.v_comp, self.u_comp_std, self.v_comp_std,
         self.uv_comp_pts.
         """
-
-        inout.read_vel_obs(self.params, self)
+        infile = Path(self.params.io.input_dir) / self.params.obs.vel_file
+        if self.params.inversion.use_cloud_point_velocities:
+            inout.read_vel_obs(infile,
+                               self.params.inversion.use_cloud_point_velocities,
+                               self)
+        else:
+            inout.read_vel_obs(infile, self)
         # Functions for repeated ungridded interpolation
         # TODO - this will not handle extrapolation/missing data
         # nicely - unfound simplex are returned '-1' which takes the last
@@ -246,8 +252,10 @@ class model:
         Q_coords = self.Q.tabulate_dof_coordinates()
         M_coords = self.M.tabulate_dof_coordinates()
 
-        vtx_Q, wts_Q = interp_weights(self.uv_comp_pts, Q_coords)
-        vtx_M, wts_M = interp_weights(self.uv_comp_pts, M_coords)
+        vtx_Q, wts_Q = interp_weights(self.vel_obs['uv_comp_pts'][0],
+                                      Q_coords)
+        vtx_M, wts_M = interp_weights(self.vel_obs['uv_comp_pts'][0],
+                                      M_coords)
 
         # Define new functions to hold results
         self.u_obs_Q = Function(self.Q, name="u_obs", static=True)
@@ -263,19 +271,19 @@ class model:
         self.mask_vel_M = Function(self.M, name="mask_vel", static=True)
 
         # Fill via interpolation
-        self.u_obs_Q.vector()[:] = interpolate(self.u_comp, vtx_Q, wts_Q)
-        self.v_obs_Q.vector()[:] = interpolate(self.v_comp, vtx_Q, wts_Q)
-        self.u_std_Q.vector()[:] = interpolate(self.u_comp_std, vtx_Q, wts_Q)
-        self.v_std_Q.vector()[:] = interpolate(self.v_comp_std, vtx_Q, wts_Q)
+        self.u_obs_Q.vector()[:] = interpolate(self.vel_obs['u_comp'][0], vtx_Q, wts_Q)
+        self.v_obs_Q.vector()[:] = interpolate(self.vel_obs['v_comp'][0], vtx_Q, wts_Q)
+        self.u_std_Q.vector()[:] = interpolate(self.vel_obs['u_comp_std'][0], vtx_Q, wts_Q)
+        self.v_std_Q.vector()[:] = interpolate(self.vel_obs['v_comp_std'][0], vtx_Q, wts_Q)
         # self.mask_vel_Q.vector()[:] = interpolate(self.mask_vel, vtx_Q, wts_Q)
 
-        self.u_obs_M.vector()[:] = interpolate(self.u_comp, vtx_M, wts_M)
-        self.v_obs_M.vector()[:] = interpolate(self.v_comp, vtx_M, wts_M)
+        self.u_obs_M.vector()[:] = interpolate(self.vel_obs['u_comp'][0], vtx_M, wts_M)
+        self.v_obs_M.vector()[:] = interpolate(self.vel_obs['v_comp'][0], vtx_M, wts_M)
         # self.u_std_M.vector()[:] = interpolate(self.u_std, vtx_M, wts_M)
         # self.v_std_M.vector()[:] = interpolate(self.v_std, vtx_M, wts_M)
         # IMPORTANT! this mask is not the vel mask of cloud point observations
         # it is the mask from the composite velocities
-        self.mask_vel_M.vector()[:] = interpolate(self.mask_vel, vtx_M, wts_M)
+        self.mask_vel_M.vector()[:] = interpolate(self.vel_obs['mask_vel'][0], vtx_M, wts_M)
 
     def init_vel_obs_old(self, u, v, mv, ustd=Constant(1.0),
                          vstd=Constant(1.0), ls=False):

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -215,8 +215,8 @@ class model:
         infile = Path(self.params.io.input_dir) / self.params.obs.vel_file
         if self.params.inversion.use_cloud_point_velocities:
             inout.read_vel_obs(infile,
-                               self.params.inversion.use_cloud_point_velocities,
-                               self)
+                               self,
+                               self.params.inversion.use_cloud_point_velocities)
         else:
             inout.read_vel_obs(infile, self)
         # Functions for repeated ungridded interpolation

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -284,8 +284,6 @@ class model:
         self.mask_vel_int = interpolate_with_griddata(x_vel, y_vel, self.mask_vel,
                                                    xx, yy)
 
-        #From here still needs modifications!
-
         vtx_Q, wts_Q = interp_weights(self.uv_obs_pts_new, Q_coords)
         vtx_M, wts_M = interp_weights(self.uv_obs_pts_new, M_coords)
 

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -92,11 +92,11 @@ class ssa_solver:
 
         # Save observations for inversions
         try:
-            self.u_obs = model.u_obs
-            self.v_obs = model.v_obs
-            self.u_std = model.u_std
-            self.v_std = model.v_std
-            self.uv_obs_pts = model.uv_obs_pts
+            self.u_obs = model.vel_obs['u_obs'][0]
+            self.v_obs = model.vel_obs['v_obs'][0]
+            self.u_std = model.vel_obs['u_std'][0]
+            self.v_std = model.vel_obs['v_std'][0]
+            self.uv_obs_pts = model.vel_obs['uv_obs_pts'][0]
         except:
             pass
 

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -92,11 +92,11 @@ class ssa_solver:
 
         # Save observations for inversions
         try:
-            self.u_obs = model.vel_obs['u_obs'][0]
-            self.v_obs = model.vel_obs['v_obs'][0]
-            self.u_std = model.vel_obs['u_std'][0]
-            self.v_std = model.vel_obs['v_std'][0]
-            self.uv_obs_pts = model.vel_obs['uv_obs_pts'][0]
+            self.u_obs = model.vel_obs['u_obs']
+            self.v_obs = model.vel_obs['v_obs']
+            self.u_std = model.vel_obs['u_std']
+            self.v_std = model.vel_obs['v_std']
+            self.uv_obs_pts = model.vel_obs['uv_obs_pts']
         except:
             pass
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -112,7 +112,7 @@ def test_initialize_vel_obs(request, setup_deps, temp_model):
     initialize_vel_obs(mdl)
 
     assert mdl.u_obs_Q is not None  # TODO - better test here
-    assert mdl.vel_obs['uv_obs_pts'][0].size > 0
+    assert mdl.vel_obs['uv_obs_pts'].size > 0
     assert np.linalg.norm(mdl.latbc.vector()[:]) != 0.0
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -29,7 +29,6 @@ def init_model(model_dir, toml_file):
 
     # Switch to the working directory
     os.chdir(model_dir)
-    print(model_dir/toml_file)
     assert (model_dir/toml_file).exists()
 
     # Get the relevant filenames from test case
@@ -108,9 +107,7 @@ def test_initialize_vel_obs(request, setup_deps, temp_model):
     setup_deps.set_case_dependency(request, ["test_initialize_fields"])
 
     work_dir = temp_model["work_dir"]
-    print(work_dir)
     toml_file = temp_model["toml_filename"]
-    print(toml_file)
     mdl = init_model(work_dir, toml_file)
     initialize_vel_obs(mdl)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -29,6 +29,7 @@ def init_model(model_dir, toml_file):
 
     # Switch to the working directory
     os.chdir(model_dir)
+    print(model_dir/toml_file)
     assert (model_dir/toml_file).exists()
 
     # Get the relevant filenames from test case
@@ -107,12 +108,14 @@ def test_initialize_vel_obs(request, setup_deps, temp_model):
     setup_deps.set_case_dependency(request, ["test_initialize_fields"])
 
     work_dir = temp_model["work_dir"]
+    print(work_dir)
     toml_file = temp_model["toml_filename"]
+    print(toml_file)
     mdl = init_model(work_dir, toml_file)
     initialize_vel_obs(mdl)
 
     assert mdl.u_obs_Q is not None  # TODO - better test here
-    assert mdl.uv_obs_pts.size > 0
+    assert mdl.vel_obs['uv_obs_pts'][0].size > 0
     assert np.linalg.norm(mdl.latbc.vector()[:]) != 0.0
 
 

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -87,7 +87,8 @@ def test_tv_run_inversion(persistent_temp_model, monkeypatch):
 
     if alpha_active:
 
-        fwd_alpha = mdl_out.solvers[0].forward_alpha
+        #fwd_alpha = mdl_out.solvers[0].forward_alpha
+        fwd_alpha = mdl_out.solvers[0].forward
         alpha = mdl_out.solvers[0].alpha
 
         min_order = taylor_test_tlm(fwd_alpha,
@@ -110,7 +111,8 @@ def test_tv_run_inversion(persistent_temp_model, monkeypatch):
 
     if beta_active:
 
-        fwd_beta = mdl_out.solvers[0].forward_beta
+        #fwd_beta = mdl_out.solvers[0].forward_beta
+        fwd_beta = mdl_out.solvers[0].forward
         beta = mdl_out.solvers[0].beta
 
         min_order = taylor_test_tlm(fwd_beta,
@@ -181,7 +183,6 @@ def test_tv_run_forward(existing_temp_model, monkeypatch, setup_deps, request):
 
     # Switch to the working directory
     monkeypatch.chdir(work_dir)
-
     EQReset()
 
     mdl_out = run_forward.run_forward(toml_file)
@@ -203,9 +204,9 @@ def test_tv_run_forward(existing_temp_model, monkeypatch, setup_deps, request):
     def forward_ts(cntrl, cntrl_init, name):
         slvr.reset_ts_zero()
         if(name == 'alpha'):
-            slvr.alpha = cntrl
+            slvr._alpha = cntrl
         elif(name == 'beta'):
-            slvr.beta = cntrl
+            slvr._beta = cntrl
         else:
             raise ValueError(f"Unrecognised cntrl name: {name}")
 
@@ -213,9 +214,9 @@ def test_tv_run_forward(existing_temp_model, monkeypatch, setup_deps, request):
 
         # Reset after simulation - confirmed necessary
         if(name == 'alpha'):
-            slvr.alpha = cntrl_init
+            slvr._alpha = cntrl_init
         elif(name == 'beta'):
-            slvr.beta = cntrl_init
+            slvr._beta = cntrl_init
         else:
             raise ValueError(f"Bad control name {name}")
 

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -87,7 +87,6 @@ def test_tv_run_inversion(persistent_temp_model, monkeypatch):
 
     if alpha_active:
 
-        #fwd_alpha = mdl_out.solvers[0].forward_alpha
         fwd_alpha = mdl_out.solvers[0].forward
         alpha = mdl_out.solvers[0].alpha
 
@@ -111,7 +110,6 @@ def test_tv_run_inversion(persistent_temp_model, monkeypatch):
 
     if beta_active:
 
-        #fwd_beta = mdl_out.solvers[0].forward_beta
         fwd_beta = mdl_out.solvers[0].forward
         beta = mdl_out.solvers[0].beta
 


### PR DESCRIPTION
Hi, 

I decided to make a first commit to show the changes that I've done so far. I will add @jrmaddison as reviewer and we can keep making changes until we are all happy with the merge.

The goal for the changes was to:
1.  Read and process a velocity file that contains always a composite mean of ice velocities & uncertainties. So the model can use such velocities for everything (alpha ini, BC definitions and J_cost optimization)
2. Read and process a velocity file that contains two type of velocities (cloud point data and composite data). So the the model can distinguish when cloud point data is found in the file and select such data for J_cost optimization only!

> As a side note: when we talk about composite we talk about a time series mean of ice velocities in this case it can be [ITSlive](https://nsidc.org/apps/itslive/) or [MEaSUREs](https://nsidc.org/sites/nsidc.org/files/NSIDC-0484-V002-UserGuide.pdf) composite mean (for measures time_coverage_start :1995-01-01 time_coverage_end :2016-12-31) more information in the corresponding links to the data products 

To achieve the goal I added a parameter to the [`.toml`](https://github.com/bearecinos/smith_glacier/blob/main/scripts/run_stages/run_inversion/smith.toml#L68) file, at the `[[inversion]]` section: `use_cloud_point_velocities = true`. If true will read in cloud point data from the velocity file and use that for the J_cost optimization. 

At the moment we will always use composite velocities for alpha init and BC definitions, even if we also read cloud point data, as we all agreed that is the best first guess.

Changes to the code are the following:
-------------------------------------------

- .gitignore: the usual hidden stuff that gets generated on my pc

- [config.py#L176](https://github.com/bearecinos/fenics_ice/blob/vel_obs/fenics_ice/config.py#L176). 
   > **Question**: do we need an `assert` in [here](https://github.com/bearecinos/fenics_ice/blob/vel_obs/fenics_ice/config.py#L184) that checks `use_cloud_point_velocities:` should always be *false*?

- [model.py#L195-L278 / `vel_obs_from_data(self)`](https://github.com/bearecinos/fenics_ice/blob/vel_obs/fenics_ice/model.py#L195-L278)
   > From here the biggest change happens in `inout.read_vel_obs(self.params, self)`, **so outside model.py**: 🔽 


- [inout.py#L307-L387, `read_vel_obs(params, model=None)`](https://github.com/bearecinos/fenics_ice/blob/vel_obs/fenics_ice/inout.py#L307-L387):

Here, I basically define two list of variables `_obs` and `_comp`  inside the model object.
- `_obs` are the velocity components and uncertainties to be use for the **J_cost optimization**.
- `_comp` are the velocity components and uncertainties to be use for **alpha initialization and BC definitions**. (Check changes in [model.py](https://github.com/bearecinos/fenics_ice/blob/vel_obs/fenics_ice/model.py#L266-L278) which define those variables.)

The two cases to be evaluated in [`read_vel_obs(params, model=None)`](https://github.com/bearecinos/fenics_ice/blob/vel_obs/fenics_ice/inout.py#L307-L387) are:

1) If **u_obs** is not found inside the `vel.h5` file the code raises an **error** as the velocity file needs to have the following format:
`u_obs`, `v_obs`, `u_std`, `v_std`, `mask_vel`, `x`, `y` , with each var stored as tuple (values, )

> If those are the only keys found in the file, the function assigns all `_obs` file vars to **both model objects**: `_obs` and `_comp`. So as default we will be using composite velocities for everything (alpha init, BC definitions and inversion)

> By default we assume that the user will always define the `_obs` variables with composite data.

2) **If there is extra data** (cloud point data defined with the string name `_cloud`) and the param `use_cloud_point_velocities` is set to *true*, the user should have in the `vel.h5` file NOT JUST COMPOSITE data (`u_obs`, `v_obs`, `u_std`, `v_std`, `mask_vel`, `x`, `y`) but also data with the following format:
`x_cloud`, `y_cloud`, `u_cloud`, `v_cloud`, `u_cloud_std`, `v_cloud_std`, each var stored as tuple (values,)
> If that is the case then the `_cloud` vars are assign to the model `_obs` objects for the J_cost optimization. 
> For the alpha init and BC definitions (so `_comp` model objects) we will always chose the composite velocity components and uncertainties defined in the file as `_obs`.  

Hopefully this is clear enough... 
You can also see in [model.py#L195-L278 / `vel_obs_from_data(self)`](https://github.com/bearecinos/fenics_ice/blob/vel_obs/fenics_ice/model.py#L195-L278) that the only changed I have done is change the velocity variables names for alpha and BC from obs to comp ... so we always use the composite mean read from the velocity file for alpha initialization and BC definition. 

I guess we should close issue #12  once we are happy with the changes.
