### PR TITLE
Penalise variation of beta only where ice is grounded AND there is available data.

### DIFF
--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -366,6 +366,7 @@ class IOCfg(ConfigPrinter):
     bmelt_data_file: str = None
     smb_data_file: str = None
     bglen_data_file: str = None
+    bglenmask_data_file: str = None
     alpha_data_file: str = None
 
     thick_field_name: str = "thick"
@@ -374,6 +375,7 @@ class IOCfg(ConfigPrinter):
     bmelt_field_name: str = "bmelt"
     smb_field_name: str = "smb"
     bglen_field_name: str = "Bglen"
+    bglenmask_field_name: str = "Bglen"
     alpha_field_name: str = "alpha"
 
     inversion_file: str = None

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -377,7 +377,7 @@ class IOCfg(ConfigPrinter):
     bmelt_field_name: str = "bmelt"
     smb_field_name: str = "smb"
     bglen_field_name: str = "Bglen"
-    bglenmask_field_name: str = "Bglen"
+    bglenmask_field_name: str = "Bglenmask"
     alpha_field_name: str = "alpha"
 
     inversion_file: str = None

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -410,7 +410,7 @@ class InputData(object):
         self.input_dir = params.io.input_dir
 
         # List of fields to search for
-        field_list = ["thick", "bed", "bmelt", "smb", "Bglen", "alpha"]
+        field_list = ["thick", "bed", "bmelt", "smb", "Bglen", "Bglenmask", "alpha"]
 
         # Dictionary of filenames & field names (i.e. field to get from HDF5 file)
         # Possibly equal to None for variables which have sensible defaults

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -25,7 +25,6 @@ from fenics_ice import inout, prior
 from fenics_ice import mesh as fice_mesh
 from numpy.random import randn
 import logging
-from IPython import embed
 
 log = logging.getLogger("fenics_ice")
 

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -149,7 +149,7 @@ class model:
         """Get bglen field from initial input data"""
         self.bglen = self.input_data.interpolate("Bglen", self.Q)
         """Get bglen mask field from input data"""
-        bglen_mask_CG = self.input_data.interpolate("Bglenmask", self.Q)
+        bglen_mask_CG = self.input_data.interpolate("Bglenmask", self.Q, default=1.0)
         self.bglen_mask = Function(self.M, name="bglen_mask")
 
         dofmap_M = self.M.dofmap()

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -25,6 +25,7 @@ from fenics_ice import inout, prior
 from fenics_ice import mesh as fice_mesh
 from numpy.random import randn
 import logging
+from IPython import embed
 
 log = logging.getLogger("fenics_ice")
 
@@ -147,7 +148,17 @@ class model:
     def bglen_from_data(self):
         """Get bglen field from initial input data"""
         self.bglen = self.input_data.interpolate("Bglen", self.Q)
+        """Get bglen mask field from input data"""
+        self.bglen_mask = self.input_data.interpolate("Bglenmask", self.M)
 
+        """bglen_mask is currently just bglen where data available and nan elsehere"""
+        """Following is hacky way to convert this to 0 where nan, 1 elsewhere"""
+        temp_vec = self.bglen_mask.vector()[:]
+        temp_vec[np.isnan(temp_vec)] = 0.0
+        temp_vec[temp_vec>0.0]=1.0
+        self.bglen_mask.vector()[:] = temp_vec
+        """Following appears in inout.interpolate -- is something similar needed?"""
+        self.bglen_mask.vector().apply("insert")
 
     def alpha_from_inversion(self):
         """Get alpha field from inversion step"""

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -161,7 +161,7 @@ class model:
         for cell in range(self.mesh.num_cells()):
           if not Cell(self.mesh, cell).is_ghost():
             local_dofs = dofmap_Q.cell_dofs(cell)
-            global_dofs = np.empty(np.shape(local_dofs),dtype=int)
+            global_dofs = np.full(np.shape(local_dofs),-1,dtype=int)
             for dof in range(len(local_dofs)):
               global_dofs[dof] = dofmap_Q.local_to_global_index(local_dofs[dof])
             if (temp_vec[global_dofs] < 1.0-1.0e-10).any():

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -149,14 +149,25 @@ class model:
         """Get bglen field from initial input data"""
         self.bglen = self.input_data.interpolate("Bglen", self.Q)
         """Get bglen mask field from input data"""
-        self.bglen_mask = self.input_data.interpolate("Bglenmask", self.M)
+        bglen_mask_CG = self.input_data.interpolate("Bglenmask", self.Q)
+        self.bglen_mask = Function(self.M, name="bglen_mask")
 
-        """bglen_mask is currently just bglen where data available and nan elsehere"""
-        """Following is hacky way to convert this to 0 where nan, 1 elsewhere"""
-        temp_vec = self.bglen_mask.vector()[:]
-        temp_vec[np.isnan(temp_vec)] = 0.0
-        temp_vec[temp_vec>0.0]=1.0
-        self.bglen_mask.vector()[:] = temp_vec
+        dofmap_M = self.M.dofmap()
+        dofmap_Q = self.Q.dofmap()
+
+        """bglen_mask is currently 1 where there is data, zero elsewhere"""
+        temp_vec = bglen_mask_CG.vector().gather(np.arange(self.Q.dim()))
+        bmask_loc = np.ones(self.bglen_mask.vector().local_size(), dtype=np.float64)
+        for cell in range(self.mesh.num_cells()):
+          if not Cell(self.mesh, cell).is_ghost():
+            local_dofs = dofmap_Q.cell_dofs(cell)
+            global_dofs = np.empty(np.shape(local_dofs),dtype=int)
+            for dof in range(len(local_dofs)):
+              global_dofs[dof] = dofmap_Q.local_to_global_index(local_dofs[dof])
+            if (temp_vec[global_dofs] < 1.0-1.0e-10).any():
+              bmask_loc[dofmap_M.cell_dofs(cell)] = 0
+
+        self.bglen_mask.vector().set_local(bmask_loc)
         """Following appears in inout.interpolate -- is something similar needed?"""
         self.bglen_mask.vector().apply("insert")
 

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -20,6 +20,7 @@ from tlm_adjoint.fenics import *
 import ufl
 from .decorators import count_calls, timer, flag_errors
 from abc import ABC, abstractmethod
+from IPython import embed
 
 class Prior(ABC):
     """Abstraction for prior used by both comp_J_inv and run_eigendec.py"""
@@ -300,7 +301,7 @@ class Laplacian_flt(Laplacian):
 
     def __init__(self, slvr, space):
         """Get flotation condition & delta_beta_gnd"""
-        self.fl_ex = slvr.float_conditional(slvr.H)
+        self.fl_ex = slvr.bglen_data_conditional(slvr.H,slvr.model.bglen_mask)
         self.delta_beta_gnd = slvr.delta_beta_gnd
 
         super().__init__(slvr, space)
@@ -330,10 +331,10 @@ class Laplacian_flt(Laplacian):
         if self.beta_active:
 
             self.terms['delta_beta'] = \
-                self.delta_beta * fl_ex * inner(beta_diff, self.test[self.beta_idx]) * dx
+                self.delta_beta * (1.0-fl_ex) * inner(beta_diff , self.test[self.beta_idx]) * dx
 
             self.terms['delta_beta_gnd'] = \
-                (self.delta_beta_gnd * (1.0 - fl_ex) *
+                (self.delta_beta_gnd * fl_ex *
                  inner(beta_diff, self.test[self.beta_idx])) * dx
 
             self.terms['gamma_beta'] = \

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -20,7 +20,6 @@ from tlm_adjoint.fenics import *
 import ufl
 from .decorators import count_calls, timer, flag_errors
 from abc import ABC, abstractmethod
-from IPython import embed
 
 class Prior(ABC):
     """Abstraction for prior used by both comp_J_inv and run_eigendec.py"""

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -1069,7 +1069,7 @@ class ssa_solver:
              rhoi = constants.rhoi
              H_float = -(rhow/rhoi) * self.bed
 
-            fl_beta_mask = ufl.operators.Conditional(ufl.operators.And(H <= H_float, self.model.bglen_mask > 0.0),
+            fl_beta_mask = ufl.operators.Conditional(ufl.operators.And(H > H_float, self.model.bglen_mask > 0.0),
                                           Constant(1.0, cell=triangle, name="Const data"),
                                           Constant(0.0, cell=triangle, name="Const no data"))
 

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -1085,7 +1085,7 @@ class ssa_solver:
              rhoi = constants.rhoi
              H_float = -(rhow/rhoi) * self.bed
 
-            fl_beta_mask = ufl.operators.Conditional(ufl.operators.And(H > H_float, self.model.bglen_mask > 0.0),
+            fl_beta_mask = ufl.operators.Conditional(ufl.operators.And(H > H_float, self.model.bglen_mask == 1),
                                           Constant(1.0, cell=triangle, name="Const data"),
                                           Constant(0.0, cell=triangle, name="Const no data"))
 

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -476,8 +476,6 @@ class ssa_solver:
 
         momsolver.solve(annotate=annotate_flag)
 
-        t1 = time.time()
-        info("Time for solve: {0}".format(t1-t0))
 
     def def_thickadv_eq(self):
         """
@@ -716,8 +714,17 @@ class ssa_solver:
         # self.test_outfile << self.alpha
 
         self.def_mom_eq()
+
+        t0 = time.time()
         self.solve_mom_eq()
+        t1 = time.time()
+        info("Time for solve: {0}".format(t1-t0))
+
+        t0 = time.time()
         J = self.comp_J_inv()
+        t1 = time.time()
+        info("Time for cost eval: {0}".format(t1-t0))
+
         return J
 
     def get_control(self):
@@ -1047,6 +1054,29 @@ class ssa_solver:
 
         return fl_ex
 
+    def bglen_data_conditional(self, H, glen_mask, H_float=None):
+        """Compute a ufl Conditional where floating=1, grounded=0"""
+
+        if not self.params.ice_dynamics.allow_flotation:
+            fl_beta_mask = ufl.operators.Conditional(self.model.bglen_mask == 1, 
+                                          Constant(1.0, cell=triangle, name="Const data"),
+                                          Constant(0.0, cell=triangle, name="Const no data"))
+        else:
+            
+            if H_float is None:
+             constants = self.params.constants
+             rhow = constants.rhow
+             rhoi = constants.rhoi
+             H_float = -(rhow/rhoi) * self.bed
+
+            fl_beta_mask = ufl.operators.Conditional(ufl.operators.And(H <= H_float, self.model.bglen_mask > 0.0),
+                                          Constant(1.0, cell=triangle, name="Const data"),
+                                          Constant(0.0, cell=triangle, name="Const no data"))
+
+        # Note: cell=triangle just suppresses a UFL warning ("missing cell")
+
+        return fl_beta_mask
+
     def comp_J_inv(self, verbose=False):
         """
         Compute the value of the cost function
@@ -1266,6 +1296,7 @@ class ssa_solver:
             info('')
 
             inout.dict_to_csv(J_fields, 'Js', self.params)
+
 
         return J
 


### PR DESCRIPTION
This change addresses a bug relating to prior.py. Addresses [Issue 14](https://github.com/EdiGlacUQ/fenics_ice/issues/14)

Existing Behavior:

prior.Laplacian_flt.prior_form makes use of solver.float_conditional to define the prior functional/distribution, penalising (with weight delta_beta_gnd) variation between beta and an imposed function for beta (based on temperature-derived ice stiffness Bglen/Bbar) -- lines 335-337. This is applied wherever ice is grounded. The imported beta field (also used as initial guess for beta) is currently extrapolated from the coverage of a larger externally produced data product. This means that where ice is grounded, but the external data product is undefined, this condition is still applied. 

The modification consists of:
1. Changing model.bglen_from_data to read in 2 fields: one is an extrapolated product to generate initial guess for beta. Other ("Bglenmask") is a field which is NaN where the original prodocut is not provided; this is interpolated to a DG(0) function and set to 0 where nan, 1 otherwise. (changes made to config.py and inout.py to enable this.)
2. Define a new conditional solver.bglen_data_conditional that is true where (a) ice is grounded and (b) a data constraint on beta exists.
3. Modify prior.Laplacian_flt.prior_form to use the difference between beta and beta_bgd only where this new conditional is true. beta_bgd is THE SAME as before this fix, but should be "correct" as the constraint is only applied where the external field is available. 

NOTE: this approach means there could be DoFs where the values used to constrain in (3) are in fact derived from extrapolation on the original product grid. A safer way to do this would be to read "Bglenmask" from the .h5 file as a CG(1) function, determine all elements where one vertex is nan, and define a new DG(0) function that is 1 only where all 3 vertices are non-nan. But I do not know how to do this. This result would replace model.bglen_mask.

NOTE: Smith_glacier repository must be updated to create 2 .h5 files (or an .h5 file with 2 fields). I will lead this.