### PR TITLE
changes in pytest markers: added order & dependency

### DIFF
--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -65,4 +65,4 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/fenics_ice/
           pytest -v --order-scope=module --color=yes
-          mpirun -n 2 pytest -v --order-scope=module --color=yes
+          mpirun -n 2 pytest -v -s --order-scope=module --color=yes

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -65,4 +65,4 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/fenics_ice/
           pytest -v --order-scope=module --color=yes
-          mpirun -n 2 pytest -v -s --order-scope=module --color=yes
+          mpirun -n 2 pytest -v --order-scope=module --color=yes

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -64,5 +64,5 @@ jobs:
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/fenics_ice/
-          pytest -v --color=yes
-          mpirun -n 2 pytest -v --color=yes
+          pytest -v --order-scope=module --color=yes
+          mpirun -n 2 pytest -v --order-scope=module --color=yes

--- a/environment.yml
+++ b/environment.yml
@@ -25,4 +25,5 @@ dependencies:
   - pytest-benchmark
   - pytest-mpi
   - pytest-dependency
+  - pytest-order
   - cytoolz

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -329,7 +329,7 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
     """
     assert infile.exists(), f"Couldn't find velocity observations file: {infile}"
 
-    with h5py.File(infile, 'r') as infile:
+    with h5py.File(infile, 'r', libver='latest', swmr=True) as infile:
         # Read composite mean of velocity data as default
         mask_vel = field_from_vel_file(infile, 'mask_vel')
         x = field_from_vel_file(infile, 'x')
@@ -348,6 +348,7 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
             v_cloud = field_from_vel_file(infile, 'v_cloud')
             u_cloud_std = field_from_vel_file(infile, 'u_cloud_std')
             v_cloud_std = field_from_vel_file(infile, 'v_cloud_std')
+            infile.close()
         else:
             x_cloud = x.copy()
             y_cloud = y.copy()

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -348,7 +348,6 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
             v_cloud = field_from_vel_file(infile, 'v_cloud')
             u_cloud_std = field_from_vel_file(infile, 'u_cloud_std')
             v_cloud_std = field_from_vel_file(infile, 'v_cloud_std')
-
         else:
             x_cloud = x.copy()
             y_cloud = y.copy()

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -329,7 +329,7 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
     """
     assert infile.exists(), f"Couldn't find velocity observations file: {infile}"
 
-    with h5py.File(infile, 'r', libver='latest', swmr=True) as infile:
+    with h5py.File(infile, 'r') as infile:
         # Read composite mean of velocity data as default
         mask_vel = field_from_vel_file(infile, 'mask_vel')
         x = field_from_vel_file(infile, 'x')
@@ -348,7 +348,7 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
             v_cloud = field_from_vel_file(infile, 'v_cloud')
             u_cloud_std = field_from_vel_file(infile, 'u_cloud_std')
             v_cloud_std = field_from_vel_file(infile, 'v_cloud_std')
-            infile.close()
+
         else:
             x_cloud = x.copy()
             y_cloud = y.copy()
@@ -357,6 +357,7 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
             u_cloud_std = u_std.copy()
             v_cloud_std = v_std.copy()
         infile.close()
+
         uv_cloud_pts = np.vstack((x_cloud, y_cloud)).T
         uv_obs_pts = np.vstack((x, y)).T
 

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -355,7 +355,7 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
             v_cloud = v_obs.copy()
             u_cloud_std = u_std.copy()
             v_cloud_std = v_std.copy()
-
+        infile.close()
         uv_cloud_pts = np.vstack((x_cloud, y_cloud)).T
         uv_obs_pts = np.vstack((x, y)).T
 
@@ -375,7 +375,6 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
         # than the composite
         sizes_pts = np.array([out[key].size for key in filter(lambda key: "_pts" in key, out)])
         sizes = np.array([out[key].size for key in filter(lambda key: "_pts" not in key, out)])
-        infile.close()
         if use_cloud_point:
             assert sizes_pts[0] < sizes_pts[-1]
             assert np.all(sizes[0:4] == sizes[0])

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -375,6 +375,7 @@ def read_vel_obs(infile, model=None, use_cloud_point=False):
         # than the composite
         sizes_pts = np.array([out[key].size for key in filter(lambda key: "_pts" in key, out)])
         sizes = np.array([out[key].size for key in filter(lambda key: "_pts" not in key, out)])
+        infile.close()
         if use_cloud_point:
             assert sizes_pts[0] < sizes_pts[-1]
             assert np.all(sizes[0:4] == sizes[0])

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -314,7 +314,7 @@ def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps, request):
                               work_dir,
                               'expected_Q_sigma_prior', tol=tol)
 
-@pytest.mark.skipif(pytest.parallel, reason='broken in parallel')
+#@pytest.mark.skipif(pytest.parallel, reason='broken in parallel')
 @pytest.mark.dependency(["test_run_eigendec"],["test_run_errorprop"])
 def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps, request):
 
@@ -332,7 +332,7 @@ def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps, request):
     expected_cntrl_sigma_prior_norm = params.testing.expected_cntrl_sigma_prior_norm
 
     EQReset()
-
+    print('run_invsigma_starts')
     mdl_out = run_invsigma.run_invsigma(toml_file)
 
     cntrl_sigma_norm = sum([norm(sig) for sig in mdl_out.cntrl_sigma])

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -135,8 +135,6 @@ def test_tv_run_inversion(persistent_temp_model, monkeypatch):
 @pytest.mark.dependency(["test_run_inversion"])
 def test_run_forward(existing_temp_model, monkeypatch, setup_deps, request):
 
-    #setup_deps.set_case_dependency(request, ["test_run_inversion"])
-
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]
 
@@ -244,8 +242,6 @@ def test_tv_run_forward(existing_temp_model, monkeypatch, setup_deps, request):
 @pytest.mark.dependency(['test_run_forward'], ['test_run_inversion'])
 def test_run_eigendec(existing_temp_model, monkeypatch, setup_deps, request):
 
-    #setup_deps.set_case_dependency(request, ["test_run_inversion"])
-
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]
 
@@ -278,8 +274,6 @@ def test_run_eigendec(existing_temp_model, monkeypatch, setup_deps, request):
 @pytest.mark.order(4)
 @pytest.mark.dependency(["test_run_eigendec", "test_run_forward"])
 def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps, request):
-
-    #setup_deps.set_case_dependency(request, ["test_run_eigendec", "test_run_forward"])
 
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]
@@ -314,11 +308,8 @@ def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps, request):
                               work_dir,
                               'expected_Q_sigma_prior', tol=tol)
 
-#@pytest.mark.skipif(pytest.parallel, reason='broken in parallel')
 @pytest.mark.dependency(["test_run_eigendec"],["test_run_errorprop"])
 def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps, request):
-
-    #setup_deps.set_case_dependency(request, ["test_run_eigendec"])
 
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]
@@ -332,7 +323,6 @@ def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps, request):
     expected_cntrl_sigma_prior_norm = params.testing.expected_cntrl_sigma_prior_norm
 
     EQReset()
-    print('run_invsigma_starts')
     mdl_out = run_invsigma.run_invsigma(toml_file)
 
     cntrl_sigma_norm = sum([norm(sig) for sig in mdl_out.cntrl_sigma])

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -314,7 +314,7 @@ def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps, request):
                               work_dir,
                               'expected_Q_sigma_prior', tol=tol)
 
-@pytest.mark.tv
+@pytest.mark.skipif(pytest.parallel, reason='broken in parallel')
 @pytest.mark.dependency(["test_run_eigendec"],["test_run_errorprop"])
 def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps, request):
 

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -314,7 +314,7 @@ def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps, request):
                               work_dir,
                               'expected_Q_sigma_prior', tol=tol)
 
-@pytest.mark.skipif(pytest.parallel, reason='broken in parallel')
+#@pytest.mark.skipif(pytest.parallel, reason='broken in parallel')
 @pytest.mark.dependency(["test_run_eigendec"],["test_run_errorprop"])
 def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps, request):
 

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -314,7 +314,7 @@ def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps, request):
                               work_dir,
                               'expected_Q_sigma_prior', tol=tol)
 
-@pytest.mark.order(5)
+@pytest.mark.tv
 @pytest.mark.dependency(["test_run_eigendec"],["test_run_errorprop"])
 def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps, request):
 

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -32,8 +32,8 @@ def EQReset():
     clear_caches()
     stop_manager()
 
+@pytest.mark.order(1)
 @pytest.mark.dependency()
-@pytest.mark.runs
 def test_run_inversion(persistent_temp_model, monkeypatch):
 
     work_dir = persistent_temp_model["work_dir"]
@@ -131,11 +131,11 @@ def test_tv_run_inversion(persistent_temp_model, monkeypatch):
                                             seed=1.0e-5)
         assert(min_order > 1.95)
 
-@pytest.mark.dependency()
-@pytest.mark.runs
+@pytest.mark.order(2)
+@pytest.mark.dependency(["test_run_inversion"])
 def test_run_forward(existing_temp_model, monkeypatch, setup_deps, request):
 
-    setup_deps.set_case_dependency(request, ["test_run_inversion"])
+    #setup_deps.set_case_dependency(request, ["test_run_inversion"])
 
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]
@@ -240,11 +240,11 @@ def test_tv_run_forward(existing_temp_model, monkeypatch, setup_deps, request):
         assert(min_order > 1.95)
 
 
-@pytest.mark.dependency()
-@pytest.mark.runs
+@pytest.mark.order(3)
+@pytest.mark.dependency(['test_run_forward'], ['test_run_inversion'])
 def test_run_eigendec(existing_temp_model, monkeypatch, setup_deps, request):
 
-    setup_deps.set_case_dependency(request, ["test_run_inversion"])
+    #setup_deps.set_case_dependency(request, ["test_run_inversion"])
 
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]
@@ -275,11 +275,11 @@ def test_run_eigendec(existing_temp_model, monkeypatch, setup_deps, request):
                               expected_evec0_norm,
                               work_dir, 'expected_evec0_norm', tol=tol)
 
-@pytest.mark.dependency()
-@pytest.mark.runs
+@pytest.mark.order(4)
+@pytest.mark.dependency(["test_run_eigendec", "test_run_forward"])
 def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps, request):
 
-    setup_deps.set_case_dependency(request, ["test_run_eigendec", "test_run_forward"])
+    #setup_deps.set_case_dependency(request, ["test_run_eigendec", "test_run_forward"])
 
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]
@@ -314,11 +314,11 @@ def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps, request):
                               work_dir,
                               'expected_Q_sigma_prior', tol=tol)
 
-@pytest.mark.dependency()
-@pytest.mark.runs
+@pytest.mark.order(5)
+@pytest.mark.dependency(["test_run_eigendec"],["test_run_errorprop"])
 def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps, request):
 
-    setup_deps.set_case_dependency(request, ["test_run_eigendec"])
+    #setup_deps.set_case_dependency(request, ["test_run_eigendec"])
 
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -314,7 +314,7 @@ def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps, request):
                               work_dir,
                               'expected_Q_sigma_prior', tol=tol)
 
-#@pytest.mark.skipif(pytest.parallel, reason='broken in parallel')
+@pytest.mark.skipif(pytest.parallel, reason='broken in parallel')
 @pytest.mark.dependency(["test_run_eigendec"],["test_run_errorprop"])
 def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps, request):
 

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -133,7 +133,7 @@ def test_tv_run_inversion(persistent_temp_model, monkeypatch):
 
 @pytest.mark.order(2)
 @pytest.mark.dependency(["test_run_inversion"])
-def test_run_forward(existing_temp_model, monkeypatch, setup_deps, request):
+def test_run_forward(existing_temp_model, monkeypatch, setup_deps):
 
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]
@@ -169,7 +169,7 @@ def test_run_forward(existing_temp_model, monkeypatch, setup_deps, request):
                               work_dir, 'expected_u_norm', tol=1.0e-5)
 
 @pytest.mark.tv
-def test_tv_run_forward(existing_temp_model, monkeypatch, setup_deps, request):
+def test_tv_run_forward(existing_temp_model, monkeypatch, setup_deps):
     """
     Taylor verification of the forward timestepping model
     """
@@ -240,7 +240,7 @@ def test_tv_run_forward(existing_temp_model, monkeypatch, setup_deps, request):
 
 @pytest.mark.order(3)
 @pytest.mark.dependency(['test_run_forward'], ['test_run_inversion'])
-def test_run_eigendec(existing_temp_model, monkeypatch, setup_deps, request):
+def test_run_eigendec(existing_temp_model, monkeypatch, setup_deps):
 
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]
@@ -273,7 +273,7 @@ def test_run_eigendec(existing_temp_model, monkeypatch, setup_deps, request):
 
 @pytest.mark.order(4)
 @pytest.mark.dependency(["test_run_eigendec", "test_run_forward"])
-def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps, request):
+def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps):
 
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]
@@ -309,7 +309,7 @@ def test_run_errorprop(existing_temp_model, monkeypatch, setup_deps, request):
                               'expected_Q_sigma_prior', tol=tol)
 
 @pytest.mark.dependency(["test_run_eigendec"],["test_run_errorprop"])
-def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps, request):
+def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps):
 
     work_dir = existing_temp_model["work_dir"]
     toml_file = existing_temp_model["toml_filename"]


### PR DESCRIPTION
Well I did these changes to get rid of issue #22 but this issue magically went away when we merged @jrmaddison latest PR. 

Let me know if you are happy with anyways merging changes that I did to the pytest which are very minor but could prevent in the future issues when the test run in parallel. 

Changes are: 

- Ordering all the test under [test_runs.py](https://github.com/bearecinos/fenics_ice/blob/main/tests/test_runs.py) with order markers and dependencies. This require the installation of another pytest plugin (pytest-order) I can remove this dependency if you want as did not fix issue #22 but it might allow us in the future to play with the order of the test when being written.
- do a f.close() in read_vel_obs() ... as suggested by @jrmaddison before (it made no difference though everything only worked once I merged your PR) 

Let me know what you think ... 