### PR TITLE
Penalise variation of beta only where ice is grounded AND there is available data. UPDATED

### DIFF
--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -25,6 +25,7 @@ from fenics_ice import inout, prior
 from fenics_ice import mesh as fice_mesh
 from numpy.random import randn
 import logging
+from IPython import embed
 
 log = logging.getLogger("fenics_ice")
 
@@ -145,9 +146,11 @@ class model:
         """Get alpha field from initial input data (run_momsolve only)"""
         self.alpha.assign(self.input_data.interpolate("alpha", self.Qp))
 
-    def bglen_from_data(self):
+    def bglen_from_data(self,mask_only=False):
         """Get bglen field from initial input data"""
-        self.bglen = self.input_data.interpolate("Bglen", self.Q)
+        if not mask_only:
+          self.bglen = self.input_data.interpolate("Bglen", self.Q)
+
         """Get bglen mask field from input data"""
         bglen_mask_CG = self.input_data.interpolate("Bglenmask", self.Q, default=1.0)
         self.bglen_mask = Function(self.M, name="bglen_mask")

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -39,6 +39,7 @@ import ufl
 import mpi4py.MPI as MPI
 import logging
 from scipy.sparse import spdiags
+from IPython import embed
 
 log = logging.getLogger("fenics_ice")
 
@@ -1074,7 +1075,7 @@ class ssa_solver:
         """Compute a ufl Conditional where floating=1, grounded=0"""
 
         if not self.params.ice_dynamics.allow_flotation:
-            fl_beta_mask = ufl.operators.Conditional(self.model.bglen_mask == 1, 
+            fl_beta_mask = ufl.operators.Conditional(ufl.eq(self.model.bglen_mask,1.0), 
                                           Constant(1.0, cell=triangle, name="Const data"),
                                           Constant(0.0, cell=triangle, name="Const no data"))
         else:
@@ -1085,7 +1086,8 @@ class ssa_solver:
              rhoi = constants.rhoi
              H_float = -(rhow/rhoi) * self.bed
 
-            fl_beta_mask = ufl.operators.Conditional(ufl.operators.And(H > H_float, self.model.bglen_mask == 1),
+
+            fl_beta_mask = ufl.operators.Conditional(ufl.operators.And(H > H_float, ufl.eq(self.model.bglen_mask,1.0)),
                                           Constant(1.0, cell=triangle, name="Const data"),
                                           Constant(0.0, cell=triangle, name="Const no data"))
 

--- a/runs/run_eigendec.py
+++ b/runs/run_eigendec.py
@@ -72,6 +72,7 @@ def run_eigendec(config_file):
     # Load alpha/beta fields
     mdl.alpha_from_inversion()
     mdl.beta_from_inversion()
+    mdl.bglen_from_data(mask_only=True)
 
     # Setup our solver object
     slvr = solver.ssa_solver(mdl, mixed_space=params.inversion.dual)

--- a/runs/run_errorprop.py
+++ b/runs/run_errorprop.py
@@ -60,6 +60,7 @@ def run_errorprop(config_file):
     # Load alpha/beta fields
     mdl.alpha_from_inversion()
     mdl.beta_from_inversion()
+    mdl.bglen_from_data(mask_only=True)
 
     # Setup our solver object
     slvr = solver.ssa_solver(mdl, mixed_space=params.inversion.dual)

--- a/runs/run_invsigma.py
+++ b/runs/run_invsigma.py
@@ -145,6 +145,7 @@ def run_invsigma(config_file):
     # Load alpha/beta fields
     mdl.alpha_from_inversion()
     mdl.beta_from_inversion()
+    mdl.bglen_from_data(mask_only=True)
 
     # Setup our solver object
     slvr = solver.ssa_solver(mdl, mixed_space=params.inversion.dual)


### PR DESCRIPTION
NOTE: this was a previous pull request 24. I ran "pytest" but not  "mpirun -n 2 pytest". As a result, there were some errors that needed to be fixed. model.bglen_from_data now is called from run_errorprop, run_eigendec and run_invsigma with a kwarg to only update bglen mask. This also fixed a bug in the definition of a ufl conditional. 

mpirun -n 2 pytest now yields fails -- but i observe they are the same fails that occurred before this PR. for this reason, i will merge without review for expedience. It can be debated later whether model.bglen_from_data should be split into separate functions which address both the prior for bglen and the mask.

Original PR text copied below, PR 24 was merged but then umerged.

--------------------------------------------------------

This change addresses a bug relating to prior.py. Addresses Issue 14

Existing Behavior:

prior.Laplacian_flt.prior_form makes use of solver.float_conditional to define the prior functional/distribution, penalising (with weight delta_beta_gnd) variation between beta and an imposed function for beta (based on temperature-derived ice stiffness Bglen/Bbar) -- lines 335-337. This is applied wherever ice is grounded. The imported beta field (also used as initial guess for beta) is currently extrapolated from the coverage of a larger externally produced data product. This means that where ice is grounded, but the external data product is undefined, this condition is still applied.

The modification consists of:

Changing model.bglen_from_data to read in 2 fields: one is an extrapolated product to generate initial guess for beta. Other ("Bglenmask") is a field which is NaN where the original prodocut is not provided; this is interpolated to a DG(0) function and set to 0 where nan, 1 otherwise. (changes made to config.py and inout.py to enable this.)
Define a new conditional solver.bglen_data_conditional that is true where (a) ice is grounded and (b) a data constraint on beta exists.
Modify prior.Laplacian_flt.prior_form to use the difference between beta and beta_bgd only where this new conditional is true. beta_bgd is THE SAME as before this fix, but should be "correct" as the constraint is only applied where the external field is available.
NOTE: this approach means there could be DoFs where the values used to constrain in (3) are in fact derived from extrapolation on the original product grid. A safer way to do this would be to read "Bglenmask" from the .h5 file as a CG(1) function, determine all elements where one vertex is nan, and define a new DG(0) function that is 1 only where all 3 vertices are non-nan. But I do not know how to do this. This result would replace model.bglen_mask.

NOTE: Smith_glacier repository must be updated to create 2 .h5 files (or an .h5 file with 2 fields). I will lead this.