### PR TITLE
Prevent invsigma test

### DIFF
--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -65,4 +65,4 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/fenics_ice/
           pytest -v --color=yes
-          mpirun -n 2 pytest -v --color=yes -k "no run_invsigma"
+          mpirun -n 2 pytest -v --color=yes -k "not run_invsigma"

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -65,4 +65,4 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/fenics_ice/
           pytest -v --color=yes
-          mpirun -n 2 pytest -v --color=yes
+          mpirun -n 2 pytest -v --color=yes -k "no run_invsigma"


### PR DESCRIPTION
A temporary fix to prevent github actions pytest from taking >6 hours by preventing invsigma run in parallel.  in 

`.github/workflows/test_fice.yml`

```python
mpirun -n 2 pytest -v --color=yes
```
is replaced by
```python
mpirun -n 2 pytest -v --color=yes -k "not run_invsigma"
```
Multiple tests still fail, mainly related to taylor verif.
