### PR TITLE
Updates to use of the tlm_adjoint manager

### DIFF
--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -610,6 +610,7 @@ class ssa_solver:
             n_sens = np.round(t_sens/dt)
 
             reset_manager()
+            clear_caches()
             start_manager()
 
             inout.configure_tlm_checkpointing(self.params)

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -610,7 +610,7 @@ class ssa_solver:
             n_sens = np.round(t_sens/dt)
 
             reset_manager()
-            start_annotating()
+            start_manager()
 
             inout.configure_tlm_checkpointing(self.params)
 
@@ -769,11 +769,9 @@ class ssa_solver:
 
         reset_manager()
         clear_caches()
-
-        start_annotating()
-
+        start_manager()
         J = forward(cntrl)
-        stop_annotating()
+        stop_manager()
 
         # Write out the gradients dJ/dAlpha & dJ/dBeta at each L-BFGS iteration
         # for debugging/analysis.
@@ -1006,9 +1004,9 @@ class ssa_solver:
         # Re-compute velocities with inversion results
         reset_manager()
         clear_caches()
-        start_annotating()
+        start_manager()
         self.solve_mom_eq()
-        stop_annotating()
+        stop_manager()
 
         # Print out inversion results/parameter values
         self.J_inv = self.comp_J_inv(verbose=True)

--- a/runs/run_eigendec.py
+++ b/runs/run_eigendec.py
@@ -207,7 +207,7 @@ def run_eigendec(config_file):
     return mdl
 
 if __name__ == "__main__":
-    stop_annotating()
+    stop_manager()
 
     assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"
     run_eigendec(sys.argv[1])

--- a/runs/run_errorprop.py
+++ b/runs/run_errorprop.py
@@ -206,7 +206,7 @@ def run_errorprop(config_file):
 
 
 if __name__ == "__main__":
-    stop_annotating()
+    stop_manager()
 
     assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"
     run_errorprop(sys.argv[1])

--- a/runs/run_forward.py
+++ b/runs/run_forward.py
@@ -37,7 +37,8 @@ import numpy as np
 import time
 import datetime
 
-stop_annotating()
+stop_manager()
+
 
 def run_forward(config_file):
 
@@ -91,7 +92,7 @@ def run_forward(config_file):
 
 
 if __name__ == "__main__":
-    stop_annotating()
+    stop_manager()
 
     assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"
     run_forward(sys.argv[1])

--- a/runs/run_inv.py
+++ b/runs/run_inv.py
@@ -130,6 +130,7 @@ def run_inv(config_file):
 
 
 if __name__ == "__main__":
-    stop_annotating()
+    stop_manager()
+
     assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"
     run_inv(sys.argv[1])

--- a/runs/run_invsigma.py
+++ b/runs/run_invsigma.py
@@ -382,7 +382,7 @@ def run_invsigma(config_file):
 
 
 if __name__ == "__main__":
-    stop_annotating()
+    stop_manager()
 
     assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"
     run_invsigma(sys.argv[1])

--- a/runs/run_momsolve.py
+++ b/runs/run_momsolve.py
@@ -76,6 +76,7 @@ def run_momsolve(config_file):
 
 
 if __name__ == "__main__":
-    stop_annotating()
+    stop_manager()
+
     assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"
     run_momsolve(sys.argv[1])


### PR DESCRIPTION
- Use `start_manager` and `stop_manager` instead of `start_annotating` and `stop_annotating`
- Always clear caches after resetting the manager

Resolves #30