### PR TITLE
Customize output and logging 

### DIFF
--- a/example_cases/ice_stream/ice_stream.toml
+++ b/example_cases/ice_stream/ice_stream.toml
@@ -12,6 +12,7 @@ alpha_data_file = "ice_stream_data.h5"
 bglen_data_file = "ice_stream_data.h5"
 
 log_level = "info" #This is default
+output_var_format = "xml"
 
 [constants]
 

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -387,6 +387,7 @@ class IOCfg(ConfigPrinter):
     sigma_prior_file: str = None  # "sigma_prior.p"
 
     log_level: str = "info"
+    output_var_format: str = "both"
 
     def set_default_filename(self, attr_name, suffix):
         """Sets a default filename (prefixed with run_name) & check suffix"""
@@ -411,6 +412,11 @@ class IOCfg(ConfigPrinter):
                                           "debug"], \
             "Invalid log level"
 
+        assert self.output_var_format in ["pvd",
+                                          "xml",
+                                          "both"], \
+            "Invalid variable output file format"
+
         fname_default_suff = {
             'inversion_file': 'invout.h5',
             'eigenvecs_file': 'vr.h5',
@@ -434,6 +440,7 @@ class TimeCfg(ConfigPrinter):
     total_steps: int = None
     dt: float = None
     num_sens: int = 1
+    save_every_tstep: bool = False
 
     def __post_init__(self):
         """

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -576,7 +576,7 @@ class ssa_solver:
                                  "relative_tolerance": 1e-11,
               })  # Not sure these solver params are necessary (linear solve)
 
-    def timestep(self, save=1, adjoint_flag=1, qoi_func=None ):
+    def timestep(self, adjoint_flag=1, qoi_func=None ):
         """
         Time evolving model
         Returns the QoI
@@ -587,6 +587,7 @@ class ssa_solver:
         n_steps = config.total_steps
         dt = config.dt
         run_length = config.run_length
+        save_every_tstep = config.save_every_tstep
 
         outdir = self.params.io.output_dir
 
@@ -638,7 +639,7 @@ class ssa_solver:
             new_block()
 
         # Write out U & H at each timestep.
-        if save:
+        if save_every_tstep:
             Hfile = Path(outdir) / "_".join((self.params.io.run_name,
                                              'H_ts.xdmf'))
             Ufile = Path(outdir) / "_".join((self.params.io.run_name,
@@ -684,12 +685,12 @@ class ssa_solver:
             if n < n_steps and adjoint_flag:
                 new_block()
 
-            if save:
+            if save_every_tstep:
                 xdmf_hts.write(H_np, t)
                 xdmf_uts.write(U_np, t)
         # End of timestepping loop
 
-        if save:
+        if save_every_tstep:
             xdmf_hts.close()
             xdmf_uts.close()
 


### PR DESCRIPTION
cc @dngoldberg 

Here are some minor changes to reduce output and stuff getting printed in the log. Issue #32 

First output:
We need some output in specific formats e.g. `xml`, `h5`, `pickle`, `csv` etc..., as fenics_ice uses that output to keep running all the stages... So those files formats stay like they are (by default). 
But for the **inversion** and **forward** run for example, have output that we definitely don't need but could still have code to reproduce that, I'm talking about formats with the `.pvd` or other paraview format extension (those files are useful to monitor a run, etc and visualize things in paraview). I think users should have the option of all formats, only default formats or only paraview file formats, and that should be control via the toml file. **Just for the inversion variables**

That is why I did the changes listed below:
- added a new config param: `output_var_format: str = "both"` (default) in the toml. this variable basically dictates the output file format for each inversion variable written by the function: [`def write_variable(var, params, name=None):`](https://github.com/bearecinos/fenics_ice/blob/38ec7529dff75f3ad98a1ea8add26d4680984a8c/fenics_ice/inout.py#L251-L294)

- added a new config param under the [time] section: [`save_every_tstep: bool = False`](https://github.com/bearecinos/fenics_ice/blob/38ec7529dff75f3ad98a1ea8add26d4680984a8c/fenics_ice/config.py#L434-L443) to let the user decide if he/she wants to save the thickness and velocity at every time step during the forward run. That introduce a better [condition here](https://github.com/bearecinos/fenics_ice/blob/38ec7529dff75f3ad98a1ea8add26d4680984a8c/fenics_ice/solver.py#L642) and [here](https://github.com/bearecinos/fenics_ice/blob/38ec7529dff75f3ad98a1ea8add26d4680984a8c/fenics_ice/solver.py#L688-L695).

Second, logging:

Basically to reduce logging information (and run things faster) the level to use is "critical", this could be use for production when we are certain about the whole workflow ... we can even go further by turning off all the printing for the newton iterations as @jrmaddison suggested before.
So far by setting the log to critical we wont see the full print for the `run_forward.py` script. Changes are [here](https://github.com/bearecinos/fenics_ice/blob/38ec7529dff75f3ad98a1ea8add26d4680984a8c/fenics_ice/inout.py#L636-L640)
```
if log_level == 'critical':
        logging.getLogger("tlm_adjoint.multistage_checkpointing").setLevel(logging.WARNING)
else:
        logging.getLogger("tlm_adjoint.multistage_checkpointing").setLevel(logging.DEBUG) 
```
Having a logging different than critical should now show you @dngoldberg the reverse messages that you see in the GMD branch. I still need to test this on Smith run_forward.sh script, as I was running the eigendecomposition and that was using all processors in bow. But will do this tomorrow.

Basically all test passed and this is ready to be merge unless you want to add more conditions and turn off more logging messages for the critical logging mode.

Cheers 
Bea