### PR TITLE
Penalise variation of beta only where ice is grounded AND there is available data

### DIFF
--- a/example_cases/smith_glacier/smith.toml
+++ b/example_cases/smith_glacier/smith.toml
@@ -140,6 +140,6 @@ patch_downscale = 0.1
 
 [testing]
 
-expected_J_inv = 566220228.1028463
+expected_J_inv = 625620918.9914922 
 # the following are needed once the input data is updated
-#expected_J_inv = 625620918.9914922 
+#expected_J_inv = 566220228.1028463

--- a/example_cases/smith_glacier/smith.toml
+++ b/example_cases/smith_glacier/smith.toml
@@ -11,9 +11,10 @@ thick_data_file = "smith_bedmachine.h5"
 bed_data_file = "smith_bedmachine.h5"
 smb_data_file = "smith_smb.h5"
 bglen_data_file = "smith_bglen.h5"
-bglenmask_data_file = "smith_bglen.h5"
 bglen_field_name = "bglen"
-bglenmask_field_name = "bglenmask"
+# the following are needed once the input data is updated
+#bglenmask_data_file = "smith_bglen.h5"
+#bglenmask_field_name = "bglenmask"
 
 log_level = "error" #This is default
 
@@ -140,3 +141,5 @@ patch_downscale = 0.1
 [testing]
 
 expected_J_inv = 566220228.1028463
+# the following are needed once the input data is updated
+#expected_J_inv = 625620918.9914922 

--- a/example_cases/smith_glacier/smith.toml
+++ b/example_cases/smith_glacier/smith.toml
@@ -12,9 +12,8 @@ bed_data_file = "smith_bedmachine.h5"
 smb_data_file = "smith_smb.h5"
 bglen_data_file = "smith_bglen.h5"
 bglen_field_name = "bglen"
-# the following are needed once the input data is updated
-#bglenmask_data_file = "smith_bglen.h5"
-#bglenmask_field_name = "bglenmask"
+bglenmask_data_file = "smith_bglen.h5"
+bglenmask_field_name = "bglenmask"
 
 log_level = "error" #This is default
 

--- a/example_cases/smith_glacier/smith.toml
+++ b/example_cases/smith_glacier/smith.toml
@@ -11,7 +11,9 @@ thick_data_file = "smith_bedmachine.h5"
 bed_data_file = "smith_bedmachine.h5"
 smb_data_file = "smith_smb.h5"
 bglen_data_file = "smith_bglen.h5"
+bglenmask_data_file = "smith_bglen.h5"
 bglen_field_name = "bglen"
+bglenmask_field_name = "bglenmask"
 
 log_level = "error" #This is default
 
@@ -137,4 +139,4 @@ patch_downscale = 0.1
 
 [testing]
 
-expected_J_inv = 625620918.9914922
+expected_J_inv = 566220228.1028463

--- a/example_cases/smith_glacier/smith.toml
+++ b/example_cases/smith_glacier/smith.toml
@@ -139,6 +139,5 @@ patch_downscale = 0.1
 
 [testing]
 
-expected_J_inv = 625620918.9914922 
-# the following are needed once the input data is updated
-#expected_J_inv = 566220228.1028463
+# expected_J_inv = 625620918.9914922 
+expected_J_inv = 566220228.1028463

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -368,6 +368,7 @@ class IOCfg(ConfigPrinter):
     bmelt_data_file: str = None
     smb_data_file: str = None
     bglen_data_file: str = None
+    bglenmask_data_file: str = None
     alpha_data_file: str = None
 
     thick_field_name: str = "thick"
@@ -376,6 +377,7 @@ class IOCfg(ConfigPrinter):
     bmelt_field_name: str = "bmelt"
     smb_field_name: str = "smb"
     bglen_field_name: str = "Bglen"
+    bglenmask_field_name: str = "Bglen"
     alpha_field_name: str = "alpha"
 
     inversion_file: str = None

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -461,7 +461,7 @@ class InputData(object):
         self.input_dir = params.io.input_dir
 
         # List of fields to search for
-        field_list = ["thick", "bed", "bmelt", "smb", "Bglen", "alpha"]
+        field_list = ["thick", "bed", "bmelt", "smb", "Bglen", "Bglenmask", "alpha"]
 
         # Dictionary of filenames & field names (i.e. field to get from HDF5 file)
         # Possibly equal to None for variables which have sensible defaults

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -145,10 +145,34 @@ class model:
         """Get alpha field from initial input data (run_momsolve only)"""
         self.alpha.assign(self.input_data.interpolate("alpha", self.Qp))
 
-    def bglen_from_data(self):
+    def bglen_from_data(self, mask_only=False):
         """Get bglen field from initial input data"""
-        self.bglen = self.input_data.interpolate("Bglen", self.Q)
 
+        if not mask_only:
+          self.bglen = self.input_data.interpolate("Bglen", self.Q)
+
+        """Get bglen mask field from input data"""
+        bglen_mask_CG = self.input_data.interpolate("Bglenmask", self.Q, default=1.0)
+        self.bglen_mask = Function(self.M, name="bglen_mask")
+
+        dofmap_M = self.M.dofmap()
+        dofmap_Q = self.Q.dofmap()
+
+        """bglen_mask is currently 1 where there is data, zero elsewhere"""
+        temp_vec = bglen_mask_CG.vector().gather(np.arange(self.Q.dim()))
+        bmask_loc = np.ones(self.bglen_mask.vector().local_size(), dtype=np.float64)
+        for cell in range(self.mesh.num_cells()):
+          if not Cell(self.mesh, cell).is_ghost():
+            local_dofs = dofmap_Q.cell_dofs(cell)
+            global_dofs = np.full(np.shape(local_dofs),-1,dtype=int)
+            for dof in range(len(local_dofs)):
+              global_dofs[dof] = dofmap_Q.local_to_global_index(local_dofs[dof])
+            if (temp_vec[global_dofs] < 1.0-1.0e-10).any():
+              bmask_loc[dofmap_M.cell_dofs(cell)] = 0
+
+        self.bglen_mask.vector().set_local(bmask_loc)
+        """Following appears in inout.interpolate"""
+        self.bglen_mask.vector().apply("insert")
 
     def alpha_from_inversion(self):
         """Get alpha field from inversion step"""

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -330,10 +330,10 @@ class Laplacian_flt(Laplacian):
         if self.beta_active:
 
             self.terms['delta_beta'] = \
-                self.delta_beta * fl_ex * inner(beta_diff, self.test[self.beta_idx]) * dx
+                self.delta_beta * (1.0-fl_ex) * inner(beta_diff, self.test[self.beta_idx]) * dx
 
             self.terms['delta_beta_gnd'] = \
-                (self.delta_beta_gnd * (1.0 - fl_ex) *
+                (self.delta_beta_gnd * fl_ex *
                  inner(beta_diff, self.test[self.beta_idx])) * dx
 
             self.terms['gamma_beta'] = \

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -300,7 +300,7 @@ class Laplacian_flt(Laplacian):
 
     def __init__(self, slvr, space):
         """Get flotation condition & delta_beta_gnd"""
-        self.fl_ex = slvr.float_conditional(slvr.H)
+        self.fl_ex = slvr.bglen_data_conditional(slvr.H,slvr.model.bglen_mask)
         self.delta_beta_gnd = slvr.delta_beta_gnd
 
         super().__init__(slvr, space)

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -1060,6 +1060,30 @@ class ssa_solver:
 
         return fl_ex
 
+    def bglen_data_conditional(self, H, glen_mask, H_float=None):
+        """Compute a ufl Conditional where floating=1, grounded=0"""
+
+        if not self.params.ice_dynamics.allow_flotation:
+            fl_beta_mask = ufl.operators.Conditional(ufl.eq(self.model.bglen_mask,1.0), 
+                                          Constant(1.0, cell=triangle, name="Const data"),
+                                          Constant(0.0, cell=triangle, name="Const no data"))
+        else:
+
+            if H_float is None:
+             constants = self.params.constants
+             rhow = constants.rhow
+             rhoi = constants.rhoi
+             H_float = -(rhow/rhoi) * self.bed
+
+
+            fl_beta_mask = ufl.operators.Conditional(ufl.operators.And(H > H_float, ufl.eq(self.model.bglen_mask,1.0)),
+                                          Constant(1.0, cell=triangle, name="Const data"),
+                                          Constant(0.0, cell=triangle, name="Const no data"))
+
+        # Note: cell=triangle just suppresses a UFL warning ("missing cell")
+
+        return fl_beta_mask
+
     def comp_J_inv(self, verbose=False):
         """
         Compute the value of the cost function

--- a/runs/run_eigendec.py
+++ b/runs/run_eigendec.py
@@ -69,6 +69,7 @@ def run_eigendec(config_file):
     # Load alpha/beta fields
     mdl.alpha_from_inversion()
     mdl.beta_from_inversion()
+    mdl.bglen_from_data(mask_only=True)
 
     # Setup our solver object
     slvr = solver.ssa_solver(mdl, mixed_space=params.inversion.dual)

--- a/runs/run_errorprop.py
+++ b/runs/run_errorprop.py
@@ -60,6 +60,7 @@ def run_errorprop(config_file):
     # Load alpha/beta fields
     mdl.alpha_from_inversion()
     mdl.beta_from_inversion()
+    mdl.bglen_from_data(mask_only=True)
 
     # Setup our solver object
     slvr = solver.ssa_solver(mdl, mixed_space=params.inversion.dual)


### PR DESCRIPTION
This change addresses a bug relating to prior.py. Addresses https://github.com/EdiGlacUQ/fenics_ice/issues/14
It is also a "resubmission" of PR24, which was undone pending a smith glacier test.

Existing Behavior:

prior.Laplacian_flt.prior_form makes use of solver.float_conditional to define the prior functional/distribution, penalising (with weight delta_beta_gnd) variation between beta and an imposed function for beta (based on temperature-derived ice stiffness Bglen/Bbar) -- lines 335-337. This is applied wherever ice is grounded. The imported beta field (also used as initial guess for beta) is currently extrapolated from the coverage of a larger externally produced data product. This means that where ice is grounded, but the external data product is undefined, this condition is still applied.

The modification consists of:

1. Changing model.bglen_from_data to read in 2 fields: one is an extrapolated product to generate initial guess for beta. Other ("Bglenmask") is a field which is 1 where the original product is provided and zero otherwise; this is interpolated to a P1 function. A DG(0) function is then defined to be zero in any cells where a vertex is less than 1. Thus the "mask" is only 1 in cells where every vertex is 1, i.e. squarely within the "data" domain. 
2. Define a new conditional solver.bglen_data_conditional that is true where (a) ice is grounded and (b) a data constraint on beta exists.
3. Modify prior.Laplacian_flt.prior_form to use the difference between beta and beta_bgd only where this new conditional is true. beta_bgd is THE SAME as before this fix, but should be "correct" as the constraint is only applied where the external field is available.

NOTE: fenics_ice_test_data/example_cases/smith_glacier/input/smith_bglen.h5 must be updated with the field to supply the mask. there is a template for this (see https://github.com/bearecinos/smith_glacier/tree/dan_update_b_bar_calculation). After this, changes need to be made to example_cases/smith_glacier/smith.toml. (the necessary changes are currently commented.) These two changes will be needed at the same time to ensure that pytest passes.