### PR TITLE
Avoid a circular reference

### DIFF
--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -63,7 +63,7 @@ class ssa_solver:
         parameters["form_compiler"]["cpp_optimize_flags"] = "-O2 -ffast-math -march=native"
         parameters["form_compiler"]["precision"] = 16
 
-        self._model = weakref.ref(model)
+        self.model = weakref.proxy(model)
         self.model.solvers.append(self)
         self.params = model.params
         self.mixed_space = mixed_space
@@ -132,13 +132,6 @@ class ssa_solver:
 
         self.eigenvals = None
         self.eigenfuncs = None
-
-    @property
-    def model(self):
-        model = self._model()
-        if model is None:
-            raise RuntimeError("referent not alive")
-        return model
 
     def set_inv_params(self):
         """Set delta_alpha, gamma_alpha, etc from config"""


### PR DESCRIPTION
Convert the ssa_solver reference to the model to a weak reference. Will lead to an error if the model is destroyed and ssa_solver.model is accessed, although it looks like this does not happen with current usage.

This resolves one possible source of deadlocks (see #22) which can occur during Python garbage collection (see https://gitlab.com/petsc/petsc/-/merge_requests/4619).