### PR TITLE
Define the pytest python_files setting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,7 @@
 
 max-line-length = 99
 extend-ignore = F403, F405, D203, D400, N806, N802, N803, W503, E201, E202, W504
+
+[tool:pytest]
+
+python_files = tests/test_*.py


### PR DESCRIPTION
Ensures that fenics_ice/test_domains.py is ignored