### PR TITLE
Output features

### DIFF
--- a/example_cases/ice_stream/ice_stream.toml
+++ b/example_cases/ice_stream/ice_stream.toml
@@ -3,6 +3,7 @@
 run_name = "ice_stream_fltgnd"
 input_dir = "./input"
 output_dir = "./output"
+diagnostics_dir = "./diagnostics"
 
 
 thick_data_file = "ice_stream_data.h5"
@@ -163,6 +164,6 @@ expected_evals_sum = 736229.8062639176
 expected_evec0_norm = 197951.57467338388
 expected_Q_sigma = 96218.0668438537
 expected_Q_sigma_prior = 27734752.37554298
-expected_cntrl_sigma_norm = 12507.05941933655
-expected_cntrl_sigma_prior_norm = 246045.26354099732
+expected_cntrl_sigma_norm = 12942.381361235446
+expected_cntrl_sigma_prior_norm = 246045.26354100602
 

--- a/example_cases/ice_stream_varres/ice_stream_varres.toml
+++ b/example_cases/ice_stream_varres/ice_stream_varres.toml
@@ -3,6 +3,7 @@
 run_name = "ice_stream_varres"
 input_dir = "./input"
 output_dir = "./output"
+diagnostics_dir = "./diagnostics"
 
 
 thick_data_file = "ice_stream_varres_data.h5"

--- a/example_cases/ismipc_30x30/ismipc_30x30.toml
+++ b/example_cases/ismipc_30x30/ismipc_30x30.toml
@@ -6,6 +6,7 @@
 run_name = "ismipc_30x30"
 input_dir = "./input"
 output_dir = "./output"
+diagnostics_dir = "./diagnostics"
 data_file = "ismipc_input.h5"
 
 # All these take default values prefixed by run_name

--- a/example_cases/ismipc_30x30/momsolve.toml
+++ b/example_cases/ismipc_30x30/momsolve.toml
@@ -6,6 +6,7 @@ run_name = "momsolve_init"
 input_dir = "./input"
 data_file = "ismipc_input.h5"
 output_dir = "./output_momsolve"
+diagnostics_dir = "./diagnostics"
 
 eigenvalue_file = "slepc_eig_all.p"
 

--- a/example_cases/ismipc_40x40/ismipc_40x40.toml
+++ b/example_cases/ismipc_40x40/ismipc_40x40.toml
@@ -6,6 +6,7 @@
 run_name = "ismipc_40x40"
 input_dir = "./input"
 output_dir = "./output"
+diagnostics_dir = "./diagnostics"
 data_file = "ismipc_input.h5"
 
 # All these take default values prefixed by run_name

--- a/example_cases/ismipc_40x40/momsolve.toml
+++ b/example_cases/ismipc_40x40/momsolve.toml
@@ -6,6 +6,7 @@ run_name = "momsolve_init"
 input_dir = "./input"
 data_file = "ismipc_input.h5"
 output_dir = "./output_momsolve"
+diagnostics_dir = "./diagnostics"
 
 eigenvalue_file = "slepc_eig_all.p"
 

--- a/example_cases/ismipc_rc_1e4/ismipc_rc_1e4.toml
+++ b/example_cases/ismipc_rc_1e4/ismipc_rc_1e4.toml
@@ -6,6 +6,7 @@
 run_name = "ismipc_rc_1e4"
 input_dir = "./input"
 output_dir = "./output"
+diagnostics_dir = "./diagnostics"
 data_file = "ismipc_input.h5"
 
 # All these take default values prefixed by run_name

--- a/example_cases/ismipc_rc_1e4/momsolve.toml
+++ b/example_cases/ismipc_rc_1e4/momsolve.toml
@@ -6,6 +6,7 @@ run_name = "momsolve_init"
 input_dir = "./input"
 data_file = "ismipc_input.h5"
 output_dir = "./output_momsolve"
+diagnostics_dir = "./diagnostics"
 
 eigenvalue_file = "slepc_eig_all.p"
 

--- a/example_cases/ismipc_rc_1e6/ismipc_rc_1e6.toml
+++ b/example_cases/ismipc_rc_1e6/ismipc_rc_1e6.toml
@@ -6,6 +6,7 @@
 run_name = "ismipc_rc_1e6"
 input_dir = "./input"
 output_dir = "./output"
+diagnostics_dir = "./diagnostics"
 
 data_file = "ismipc_input.h5"
 

--- a/example_cases/ismipc_rc_1e6/momsolve.toml
+++ b/example_cases/ismipc_rc_1e6/momsolve.toml
@@ -6,6 +6,7 @@ run_name = "momsolve_init"
 input_dir = "./input"
 data_file = "ismipc_input.h5"
 output_dir = "./output_momsolve"
+diagnostics_dir = "./diagnostics"
 
 eigenvalue_file = "slepc_eig_all.p"
 

--- a/example_cases/ismipc_rc_1e6_parallel/ismipc_rc_1e6.toml
+++ b/example_cases/ismipc_rc_1e6_parallel/ismipc_rc_1e6.toml
@@ -6,6 +6,7 @@
 run_name = "ismipc_rc_1e6"
 input_dir = "./input"
 output_dir = "./output"
+diagnostics_dir = "./diagnostics"
 data_file = "ismipc_input.h5"
 
 # All these take default values prefixed by run_name

--- a/example_cases/ismipc_rc_1e6_parallel/momsolve.toml
+++ b/example_cases/ismipc_rc_1e6_parallel/momsolve.toml
@@ -6,6 +6,7 @@ run_name = "momsolve_init"
 input_dir = "./input"
 data_file = "ismipc_input.h5"
 output_dir = "./output_momsolve"
+diagnostics_dir = "./diagnostics"
 
 eigenvalue_file = "slepc_eig_all.p"
 

--- a/example_cases/smith_glacier/smith.toml
+++ b/example_cases/smith_glacier/smith.toml
@@ -4,6 +4,7 @@
 run_name = "smith_glacier_test"
 input_dir = "./input"
 output_dir = "./output"
+diagnostics_dir = "./diagnostics"
 
 
 # data_file = "ismipc_input.h5"

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -118,8 +118,32 @@ class ConfigParser(object):
             "Unable to find input directory"
 
         outdir = (self.top_dir / self.io.output_dir)
+        diag_dir = (self.top_dir/ self.io.diagnostics_dir)
+
+        ph_names = [self.inversion.phase_name,
+                    self.time.phase_name,
+                    self.eigendec.phase_name,
+                    self.error_prop.phase_name,
+                    self.inv_sigma.phase_name]
+
+        ph_suffix = [self.inversion.phase_suffix,
+                    self.time.phase_suffix,
+                    self.eigendec.phase_suffix,
+                    self.error_prop.phase_suffix,
+                    self.inv_sigma.phase_suffix]
+
+        for ph, suff in zip(ph_names, ph_suffix):
+            out_dir = (outdir / ph / suff)
+            out_diag_dirs = (diag_dir/ ph / suff)
+            if not out_dir.is_dir():
+                out_dir.mkdir(parents=True, exist_ok=True)
+            if not out_diag_dirs.is_dir():
+                out_diag_dirs.mkdir(parents=True, exist_ok=True)
+
         if not outdir.is_dir():
             outdir.mkdir(parents=True, exist_ok=True)
+        if not diag_dir.is_dir():
+            diag_dir.mkdir(parents=True, exist_ok=True)
 
     def set_tlm_adjoint_params(self):
         """Set some parameters for tlm_adjoint"""
@@ -177,6 +201,7 @@ class InversionCfg(ConfigPrinter):
     use_cloud_point_velocities: bool = False
 
     mass_precon: bool = True
+    phase_name: str = 'inversion'
     phase_suffix: str = ''
 
     def __post_init__(self):
@@ -211,6 +236,7 @@ class ErrorPropCfg(ConfigPrinter):
     Configuration related to error propagation
     """
     qoi: str = 'vaf'
+    phase_name: str = 'error_prop'
     phase_suffix: str = ''
 
 @dataclass(frozen=True)
@@ -220,6 +246,7 @@ class InvSigmaCfg(ConfigPrinter):
     """
     patch_downscale: float = None
     npatches: int = None
+    phase_name: str = 'inv_sigma'
     phase_suffix: str = ''
 
     def __post_init__(self):
@@ -243,6 +270,7 @@ class EigenDecCfg(ConfigPrinter):
     test_ed: bool = False
     tol: float = 1.0e-10
     max_iter: int = 1e6
+    phase_name: str = 'eigendec'
     phase_suffix: str = ''
 
     def __post_init__(self):
@@ -364,6 +392,8 @@ class IOCfg(ConfigPrinter):
     run_name: str
     input_dir: str
     output_dir: str
+    diagnostics_dir: str
+    write_diagnostics: bool = False
 
     data_file: str = None
 
@@ -449,6 +479,7 @@ class TimeCfg(ConfigPrinter):
     dt: float = None
     num_sens: int = 1
     save_every_tstep: bool = False
+    phase_name: str = 'forward'
     phase_suffix: str = ''
 
     def __post_init__(self):

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -177,6 +177,7 @@ class InversionCfg(ConfigPrinter):
     use_cloud_point_velocities: bool = False
 
     mass_precon: bool = True
+    phase_suffix: str = ''
 
     def __post_init__(self):
         """
@@ -210,6 +211,7 @@ class ErrorPropCfg(ConfigPrinter):
     Configuration related to error propagation
     """
     qoi: str = 'vaf'
+    phase_suffix: str = ''
 
 @dataclass(frozen=True)
 class InvSigmaCfg(ConfigPrinter):
@@ -218,6 +220,7 @@ class InvSigmaCfg(ConfigPrinter):
     """
     patch_downscale: float = None
     npatches: int = None
+    phase_suffix: str = ''
 
     def __post_init__(self):
         """Check & supply sensible defaults"""
@@ -240,6 +243,7 @@ class EigenDecCfg(ConfigPrinter):
     test_ed: bool = False
     tol: float = 1.0e-10
     max_iter: int = 1e6
+    phase_suffix: str = ''
 
     def __post_init__(self):
         assert self.precondition_by in ["mass", "prior"], \
@@ -432,6 +436,7 @@ class IOCfg(ConfigPrinter):
 
         for fname in fname_default_suff:
             self.set_default_filename(fname, fname_default_suff[fname])
+            #embed()
 
 @dataclass(frozen=True)
 class TimeCfg(ConfigPrinter):
@@ -444,6 +449,7 @@ class TimeCfg(ConfigPrinter):
     dt: float = None
     num_sens: int = 1
     save_every_tstep: bool = False
+    phase_suffix: str = ''
 
     def __post_init__(self):
         """

--- a/fenics_ice/eigendecomposition.py
+++ b/fenics_ice/eigendecomposition.py
@@ -284,10 +284,14 @@ def slepc_monitor_callback(params, space, result_list):
     result_list["vr"] = []
 
     # Open results files
-    ev_filepath = Path(params.io.output_dir) / params.io.eigenvecs_file
+    eigenvecs_file = params.io.eigenvecs_file
+    phase_suffix = params.eigendec.phase_suffix
+    if len(phase_suffix) > 0:
+        eigenvecs_file = params.io.run_name + phase_suffix + '_vr.h5'
+
+    ev_filepath = Path(params.io.output_dir) / eigenvecs_file
     # Delete files to avoid append
     ev_filepath.unlink(missing_ok=True)
-
     p = ev_filepath
     ev_xdmf_filepath = Path(p).parent / Path(p.stem + "_vis").with_suffix(".xdmf")
 
@@ -300,7 +304,11 @@ def slepc_monitor_callback(params, space, result_list):
     ev_file = HDF5File(space.mesh().mpi_comm(), str(ev_filepath), 'w')
     ev_file.close()
 
-    lam_file = Path(params.io.output_dir) / params.io.eigenvalue_file
+    eigenvalue_file = params.io.eigenvalue_file
+    phase_suffix = params.eigendec.phase_suffix
+    if len(phase_suffix) > 0:
+        eigenvalue_file = params.io.run_name + phase_suffix + '_eigvals.p'
+    lam_file = Path(params.io.output_dir) / eigenvalue_file
 
     V_r_prev = None
 

--- a/fenics_ice/eigendecomposition.py
+++ b/fenics_ice/eigendecomposition.py
@@ -62,6 +62,7 @@ import petsc4py.PETSc as PETSc
 from pathlib import Path
 import os
 import logging
+from IPython import embed
 
 log = logging.getLogger("fenics_ice")
 
@@ -289,10 +290,12 @@ def slepc_monitor_callback(params, space, result_list):
     if len(phase_suffix) > 0:
         eigenvecs_file = params.io.run_name + phase_suffix + '_vr.h5'
 
-    ev_filepath = Path(params.io.output_dir) / eigenvecs_file
+    outdir = Path(params.io.output_dir)/params.eigendec.phase_name/params.eigendec.phase_suffix
+    diagdir = Path(params.io.diagnostics_dir)/params.eigendec.phase_name/params.eigendec.phase_suffix
+    ev_filepath = outdir / eigenvecs_file
     # Delete files to avoid append
     ev_filepath.unlink(missing_ok=True)
-    p = ev_filepath
+    p = diagdir/ eigenvecs_file
     ev_xdmf_filepath = Path(p).parent / Path(p.stem + "_vis").with_suffix(".xdmf")
 
     ev_xdmf_file = XDMFFile(space.mesh().mpi_comm(), str(ev_xdmf_filepath))
@@ -308,7 +311,7 @@ def slepc_monitor_callback(params, space, result_list):
     phase_suffix = params.eigendec.phase_suffix
     if len(phase_suffix) > 0:
         eigenvalue_file = params.io.run_name + phase_suffix + '_eigvals.p'
-    lam_file = Path(params.io.output_dir) / eigenvalue_file
+    lam_file = outdir / eigenvalue_file
 
     V_r_prev = None
 

--- a/fenics_ice/fenics_util.py
+++ b/fenics_ice/fenics_util.py
@@ -26,7 +26,6 @@ import os
 from pylab import plt
 from matplotlib import colors
 from mpl_toolkits.axes_grid1 import make_axes_locatable
-from IPython import embed
 import collections.abc
 
 def plot_variable(u, name, direc, cmap='gist_yarg', scale='lin', numLvls=12,

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -26,6 +26,7 @@ import numpy as np
 from pathlib import Path
 from numpy.random import randn
 import logging
+from IPython import embed
 
 log = logging.getLogger("fenics_ice")
 
@@ -183,10 +184,12 @@ class model:
         if len(phase_suffix) > 0:
             inversion_file = self.params.io.run_name + phase_suffix + '_invout.h5'
 
-        outdir = self.params.io.output_dir
+        outdir = Path(self.params.io.output_dir) / \
+                 self.params.inversion.phase_name / \
+                 self.params.inversion.phase_suffix
 
         with HDF5File(self.mesh.mpi_comm(),
-                      str(Path(outdir)/inversion_file),
+                      str(outdir/inversion_file),
                       'r') as infile:
             infile.read(self.alpha, 'alpha')
 
@@ -198,10 +201,12 @@ class model:
         if len(phase_suffix) > 0:
             inversion_file = self.params.io.run_name + phase_suffix + '_invout.h5'
 
-        outdir = self.params.io.output_dir
+        outdir = Path(self.params.io.output_dir) / \
+                 self.params.inversion.phase_name / \
+                 self.params.inversion.phase_suffix
 
         with HDF5File(self.mesh.mpi_comm(),
-                      str(Path(outdir)/inversion_file),
+                      str(outdir/inversion_file),
                       'r') as infile:
             infile.read(self.beta, 'beta')
 
@@ -470,8 +475,17 @@ class model:
         else:
             raise NotImplementedError(f"Don't have code for method {method}")
 
-        phase_suffix = self.params.inversion.phase_suffix
-        inout.write_variable(self.alpha, self.params, name="alpha_init_guess", phase_suffix=phase_suffix)
+        write_diag = self.params.io.write_diagnostics
+        if write_diag:
+            diag_dir = self.params.io.diagnostics_dir
+            phase_suffix = self.params.inversion.phase_suffix
+            phase_name = self.params.inversion.phase_name
+            inout.write_variable(self.alpha,
+                                 self.params,
+                                 name="alpha_init_guess",
+                                 outdir=diag_dir,
+                                 phase_name=phase_name,
+                                 phase_suffix=phase_suffix)
 
     def mark_BCs(self):
         """

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -20,6 +20,7 @@ from .backend import *
 from . import inout, prior
 from . import mesh as fice_mesh
 
+import os.path
 import ufl
 import numpy as np
 from pathlib import Path
@@ -177,6 +178,11 @@ class model:
     def alpha_from_inversion(self):
         """Get alpha field from inversion step"""
         inversion_file = self.params.io.inversion_file
+
+        phase_suffix = self.params.inversion.phase_suffix
+        if len(phase_suffix) > 0:
+            inversion_file = self.params.io.run_name + phase_suffix + '_invout.h5'
+
         outdir = self.params.io.output_dir
 
         with HDF5File(self.mesh.mpi_comm(),
@@ -187,6 +193,11 @@ class model:
     def beta_from_inversion(self):
         """Get beta field from inversion step"""
         inversion_file = self.params.io.inversion_file
+
+        phase_suffix = self.params.inversion.phase_suffix
+        if len(phase_suffix) > 0:
+            inversion_file = self.params.io.run_name + phase_suffix + '_invout.h5'
+
         outdir = self.params.io.output_dir
 
         with HDF5File(self.mesh.mpi_comm(),
@@ -459,8 +470,8 @@ class model:
         else:
             raise NotImplementedError(f"Don't have code for method {method}")
 
-
-        inout.write_variable(self.alpha, self.params, name="alpha_init_guess")
+        phase_suffix = self.params.inversion.phase_suffix
+        inout.write_variable(self.alpha, self.params, name="alpha_init_guess", phase_suffix=phase_suffix)
 
     def mark_BCs(self):
         """

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -590,6 +590,7 @@ class ssa_solver:
         save_every_tstep = config.save_every_tstep
 
         outdir = self.params.io.output_dir
+        diag_dir = self.params.io.diagnostics_dir
 
         t = 0.0
 
@@ -641,10 +642,14 @@ class ssa_solver:
         # Write out U & H at each timestep.
         if save_every_tstep:
 
+            phase_name = self.params.time.phase_name
             phase_suffix = self.params.time.phase_suffix
-            Hfile = Path(outdir) / "_".join((self.params.io.run_name + phase_suffix,
+
+            outdirsteps = Path(diag_dir)/phase_name/phase_suffix
+
+            Hfile = outdirsteps/"_".join((self.params.io.run_name + phase_suffix,
                                              'H_ts.xdmf'))
-            Ufile = Path(outdir) / "_".join((self.params.io.run_name + phase_suffix,
+            Ufile = outdirsteps/"_".join((self.params.io.run_name + phase_suffix,
                                              'U_ts.xdmf'))
 
             xdmf_hts = XDMFFile(self.mesh.mpi_comm(), str(Hfile))

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -640,9 +640,11 @@ class ssa_solver:
 
         # Write out U & H at each timestep.
         if save_every_tstep:
-            Hfile = Path(outdir) / "_".join((self.params.io.run_name,
+
+            phase_suffix = self.params.time.phase_suffix
+            Hfile = Path(outdir) / "_".join((self.params.io.run_name + phase_suffix,
                                              'H_ts.xdmf'))
-            Ufile = Path(outdir) / "_".join((self.params.io.run_name,
+            Ufile = Path(outdir) / "_".join((self.params.io.run_name + phase_suffix,
                                              'U_ts.xdmf'))
 
             xdmf_hts = XDMFFile(self.mesh.mpi_comm(), str(Hfile))
@@ -777,7 +779,11 @@ class ssa_solver:
 
         # Write out the gradients dJ/dAlpha & dJ/dBeta at each L-BFGS iteration
         # for debugging/analysis.
-        inv_grad_writer = inout.XDMFWriter(inout.gen_path(self.params, 'inv_grads', '.xdmf'),
+        phase_suffix = self.params.inversion.phase_suffix
+        inv_grad_writer = inout.XDMFWriter(inout.gen_path(self.params,
+                                                          'inv_grads',
+                                                          '.xdmf',
+                                                          phase_suffix=phase_suffix),
                                            comm=self.mesh.mpi_comm())
 
         ##########################################

--- a/fenics_ice/test_domains.py
+++ b/fenics_ice/test_domains.py
@@ -18,7 +18,6 @@
 The classes here define test domains for use with fenics_ice.
 """
 import numpy as np
-from IPython import embed
 
 class gldbg2013:
 

--- a/input/smith_500m_input/data_preproc_script.py
+++ b/input/smith_500m_input/data_preproc_script.py
@@ -23,7 +23,6 @@ import scipy.interpolate as interp
 import matplotlib.pyplot as plt
 
 import numpy as np
-from IPython import embed
 
 #########################################
 #Details of model domain grid + Constants

--- a/runs/process_eigendec.py
+++ b/runs/process_eigendec.py
@@ -25,7 +25,6 @@ mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pickle
-from IPython import embed
 
 
 def main(inputfile, outdir, dd):

--- a/runs/run_balancemeltrates.py
+++ b/runs/run_balancemeltrates.py
@@ -37,7 +37,6 @@ import numpy as np
 import time
 import datetime
 import pickle
-from IPython import embed
 
 def main(config_file):
 

--- a/runs/run_eigendec.py
+++ b/runs/run_eigendec.py
@@ -195,7 +195,8 @@ def run_eigendec(config_file):
     lind = np.arange(0, len(lam))
     plt.semilogy(lind[lpos], lam[lpos], '.')
     plt.semilogy(lind[lneg], np.abs(lam[lneg]), '.')
-    plt.savefig(os.path.join(params.io.output_dir, 'lambda.pdf'))
+    diag_dir = Path(params.io.diagnostics_dir)/params.eigendec.phase_name/params.eigendec.phase_suffix
+    plt.savefig(diag_dir/ 'lambda.pdf')
     plt.close()
 
     # Note - for now this does nothing, but eventually if the whole series

--- a/runs/run_errorprop.py
+++ b/runs/run_errorprop.py
@@ -45,10 +45,19 @@ def run_errorprop(config_file):
     # Load the static model data (geometry, smb, etc)
     input_data = inout.InputData(params)
 
+    phase_suffix_e = params.eigendec.phase_suffix
+    phase_suffix_qoi = params.time.phase_suffix
+
     lamfile = params.io.eigenvalue_file
     vecfile = params.io.eigenvecs_file
     threshlam = params.eigendec.eigenvalue_thresh
     dqoi_h5file = params.io.dqoi_h5file
+
+    if len(phase_suffix_e) > 0:
+        lamfile = params.io.run_name + phase_suffix_e + '_eigvals.p'
+        vecfile = params.io.run_name + phase_suffix_e + '_vr.h5'
+    if len(phase_suffix_qoi) > 0:
+        dqoi_h5file = params.io.run_name + phase_suffix_qoi + '_dQ_ts.h5'
 
     # Get model mesh
     mesh = fice_mesh.get_mesh(params)
@@ -174,11 +183,15 @@ def run_errorprop(config_file):
     plt.xlabel("Num eig")
 
     plt.savefig(os.path.join(params.io.output_dir,
-                             "_".join((params.io.run_name, "sigmaQoI_conv.pdf"))))
+                             "_".join((params.io.run_name,
+                                       phase_suffix_qoi +
+                                       "sigmaQoI_conv.pdf"))))
     plt.close()
 
     sigmaqoi_file = os.path.join(params.io.output_dir,
-                                 "_".join((params.io.run_name, "sigma_qoi_convergence.p")))
+                                 "_".join((params.io.run_name,
+                                           phase_suffix_qoi +
+                                           "sigma_qoi_convergence.p")))
 
     with open(sigmaqoi_file, 'wb') as pfile:
         pickle.dump([sigma_steps, sigma_conv], pfile)
@@ -193,6 +206,11 @@ def run_errorprop(config_file):
     # Output model variables in ParaView+Fenics friendly format
     sigma_file = params.io.sigma_file
     sigma_prior_file = params.io.sigma_prior_file
+
+    if len(phase_suffix_qoi) > 0:
+        sigma_file = params.io.run_name + phase_suffix_qoi + '_sigma.p'
+        sigma_prior_file = params.io.run_name + phase_suffix_qoi + '_sigma_prior.p'
+
     with open( os.path.join(outdir, sigma_file), "wb" ) as sigfile:
         pickle.dump( [sigma, t_sens], sigfile)
     with open( os.path.join(outdir, sigma_prior_file), "wb" ) as sigpfile:

--- a/runs/run_forward.py
+++ b/runs/run_forward.py
@@ -80,11 +80,14 @@ def run_forward(config_file):
     inout.write_dqval(dQ_ts, [var.name() for var in cntrl], params)
 
     # Output final velocity, surface & thickness (visualisation)
-    inout.write_variable(slvr.U, params, name="U_fwd")
-    inout.write_variable(mdl.surf, params, name="surf_fwd")
+    inout.write_variable(slvr.U, params, name="U_fwd",
+                         phase_suffix=params.time.phase_suffix)
+    inout.write_variable(mdl.surf, params, name="surf_fwd",
+                         phase_suffix=params.time.phase_suffix)
 
     H = project(mdl.H, mdl.Q)
-    inout.write_variable(H, params, name="H_fwd")
+    inout.write_variable(H, params, name="H_fwd",
+                         phase_suffix=params.time.phase_suffix)
 
     return mdl
 

--- a/runs/run_forward.py
+++ b/runs/run_forward.py
@@ -46,6 +46,8 @@ def run_forward(config_file):
     inout.log_preamble("forward", params)
 
     outdir = params.io.output_dir
+    diag_dir = params.io.diagnostics_dir
+    phase_name = params.time.phase_name
 
     # Load the static model data (geometry, smb, etc)
     input_data = inout.InputData(params)
@@ -81,14 +83,16 @@ def run_forward(config_file):
 
     # Output final velocity, surface & thickness (visualisation)
     inout.write_variable(slvr.U, params, name="U_fwd",
+                         outdir=diag_dir, phase_name=phase_name,
                          phase_suffix=params.time.phase_suffix)
     inout.write_variable(mdl.surf, params, name="surf_fwd",
+                         outdir=diag_dir, phase_name=phase_name,
                          phase_suffix=params.time.phase_suffix)
 
     H = project(mdl.H, mdl.Q)
     inout.write_variable(H, params, name="H_fwd",
+                         outdir=diag_dir, phase_name=phase_name,
                          phase_suffix=params.time.phase_suffix)
-
     return mdl
 
 

--- a/runs/run_inv.py
+++ b/runs/run_inv.py
@@ -36,7 +36,6 @@ from fenics_ice.config import ConfigParser
 # import pickle
 import datetime
 
-
 def run_inv(config_file):
     """Run the inversion part of the simulation"""
     # Read run config file
@@ -79,6 +78,11 @@ def run_inv(config_file):
     # Required for next phase (HDF5):
 
     invout_file = params.io.inversion_file
+
+    phase_suffix = params.inversion.phase_suffix
+    if len(phase_suffix) > 0:
+        invout_file = params.io.run_name + phase_suffix + '_invout.h5'
+
     invout = HDF5File(mesh.mpi_comm(), str(Path(outdir)/invout_file), 'w')
 
     invout.parameters.add("gamma_alpha", slvr.gamma_alpha)
@@ -93,39 +97,39 @@ def run_inv(config_file):
 
     # For visualisation (XML & VTK):
 
-    inout.write_variable(slvr.U, params)
-    inout.write_variable(mdl.beta, params)
+    inout.write_variable(slvr.U, params, phase_suffix=phase_suffix)
+    inout.write_variable(mdl.beta, params, phase_suffix=phase_suffix)
 
     mdl.beta_bgd.rename("beta_bgd", "")
-    inout.write_variable(mdl.beta_bgd, params)
+    inout.write_variable(mdl.beta_bgd, params, phase_suffix=phase_suffix)
 
-    inout.write_variable(mdl.bed, params)
+    inout.write_variable(mdl.bed, params, phase_suffix=phase_suffix)
     H = project(mdl.H, mdl.M)
     H.rename("thick", "")
-    inout.write_variable(H, params)
+    inout.write_variable(H, params, phase_suffix=phase_suffix)
 
     fl_ex = project(slvr.float_conditional(H), mdl.M)
-    inout.write_variable(fl_ex, params, name='float')
+    inout.write_variable(fl_ex, params, name='float', phase_suffix=phase_suffix)
 
-    inout.write_variable(mdl.mask_vel_M, params, name="mask_vel")
+    inout.write_variable(mdl.mask_vel_M, params, name="mask_vel", phase_suffix=phase_suffix)
 
-    inout.write_variable(mdl.u_obs_Q, params)
-    inout.write_variable(mdl.v_obs_Q, params)
-    inout.write_variable(mdl.u_std_Q, params)
-    inout.write_variable(mdl.v_std_Q, params)
+    inout.write_variable(mdl.u_obs_Q, params, phase_suffix=phase_suffix)
+    inout.write_variable(mdl.v_obs_Q, params, phase_suffix=phase_suffix)
+    inout.write_variable(mdl.u_std_Q, params, phase_suffix=phase_suffix)
+    inout.write_variable(mdl.v_std_Q, params, phase_suffix=phase_suffix)
 
     U_obs = project((mdl.v_obs_Q**2 + mdl.u_obs_Q**2)**(1.0/2.0), mdl.M)
     U_obs.rename("uv_obs", "")
-    inout.write_variable(U_obs, params, name="uv_obs")
+    inout.write_variable(U_obs, params, name="uv_obs", phase_suffix=phase_suffix)
 
-    inout.write_variable(mdl.alpha, params)
+    inout.write_variable(mdl.alpha, params, phase_suffix=phase_suffix)
 
     Bglen = project(slvr.beta_to_bglen(slvr.beta), mdl.M)
     Bglen.rename("Bglen", "")
-    inout.write_variable(Bglen, params)
-    inout.write_variable(slvr.bmelt, params, name="bmelt")
-    inout.write_variable(slvr.smb, params, name="smb")
-    inout.write_variable(mdl.surf, params, name="surf")
+    inout.write_variable(Bglen, params, phase_suffix=phase_suffix)
+    inout.write_variable(slvr.bmelt, params, name="bmelt", phase_suffix=phase_suffix)
+    inout.write_variable(slvr.smb, params, name="smb", phase_suffix=phase_suffix)
+    inout.write_variable(mdl.surf, params, name="surf", phase_suffix=phase_suffix)
 
     return mdl
 

--- a/runs/run_invsigma.py
+++ b/runs/run_invsigma.py
@@ -26,6 +26,7 @@ os.environ["OPENBLAS_NUM_THREADS"] = "1"
 import sys
 import pickle
 import numpy as np
+from pathlib import Path
 
 from fenics_ice import model, solver, prior, inout
 from fenics_ice import mesh as fice_mesh
@@ -60,7 +61,7 @@ def patch_fun(mesh_in, params):
 
     # Ratio of n_patches to n_cells
     if params.inv_sigma.npatches is not None:
-        ntgt = param.inv_sigma.npatches
+        ntgt = params.inv_sigma.npatches
     else:
         ntgt = int(np.floor(ncells * params.inv_sigma.patch_downscale))
 
@@ -127,15 +128,14 @@ def run_invsigma(config_file):
     inout.log_preamble("inv sigma", params)
 
     outdir = params.io.output_dir
+    diags_dir = params.io.diagnostics_dir
 
     # Load the static model data (geometry, smb, etc)
     input_data = inout.InputData(params)
 
-    eigendir = outdir
-
+    # Eigen decomposition params
     phase_suffix_e = params.eigendec.phase_suffix
-    phase_suffix_qoi = params.error_prop.phase_suffix
-
+    eigendir = Path(outdir)/params.eigendec.phase_name/phase_suffix_e
     lamfile = params.io.eigenvalue_file
     vecfile = params.io.eigenvecs_file
     threshlam = params.eigendec.eigenvalue_thresh
@@ -384,8 +384,14 @@ def run_invsigma(config_file):
 
         phase_suffix_sigma = params.inv_sigma.phase_suffix
 
-        inout.write_variable(sigmas[i], params, phase_suffix=phase_suffix_sigma)
-        inout.write_variable(sigma_priors[i], params, phase_suffix=phase_suffix_sigma)
+        inout.write_variable(sigmas[i], params,
+                             outdir=outdir,
+                             phase_name=params.inv_sigma.phase_name,
+                             phase_suffix=phase_suffix_sigma)
+        inout.write_variable(sigma_priors[i], params,
+                             outdir=outdir,
+                             phase_name=params.inv_sigma.phase_name,
+                             phase_suffix=phase_suffix_sigma)
 
     mdl.cntrl_sigma = sigmas
     mdl.cntrl_sigma_prior = sigma_priors

--- a/runs/run_invsigma.py
+++ b/runs/run_invsigma.py
@@ -132,9 +132,17 @@ def run_invsigma(config_file):
     input_data = inout.InputData(params)
 
     eigendir = outdir
+
+    phase_suffix_e = params.eigendec.phase_suffix
+    phase_suffix_qoi = params.error_prop.phase_suffix
+
     lamfile = params.io.eigenvalue_file
     vecfile = params.io.eigenvecs_file
     threshlam = params.eigendec.eigenvalue_thresh
+
+    if len(phase_suffix_e) > 0:
+        lamfile = params.io.run_name + phase_suffix_e + '_eigvals.p'
+        vecfile = params.io.run_name + phase_suffix_e + '_vr.h5'
 
     # Get model mesh
     mesh = fice_mesh.get_mesh(params)
@@ -374,8 +382,10 @@ def run_invsigma(config_file):
         sigmas[i].rename("sigma_"+name, "")
         sigma_priors[i].rename("sigma_prior_"+name, "")
 
-        inout.write_variable(sigmas[i], params)
-        inout.write_variable(sigma_priors[i], params)
+        phase_suffix_sigma = params.inv_sigma.phase_suffix
+
+        inout.write_variable(sigmas[i], params, phase_suffix=phase_suffix_sigma)
+        inout.write_variable(sigma_priors[i], params, phase_suffix=phase_suffix_sigma)
 
     mdl.cntrl_sigma = sigmas
     mdl.cntrl_sigma_prior = sigma_priors


### PR DESCRIPTION
Hi tons of changes (in 28 files! sorry!), in order to organize the output in:
- output: all files needed by the fenics ice workflow
- diagnostic: all files needed for visualization and diagnostics on the workflow 

Solves issues #46 #32 

Each directory is divided into stages defined by default when a .toml is passed [changes under config.py](https://github.com/bearecinos/fenics_ice/blob/c349d0a3767350873aa230ee26731ab11e39738a/fenics_ice/config.py#L113-L146)

The path to each of these folders must be defined in the toml, otherwise it will error:
```
[io] #Directory specification

run_name = "ice_stream"
input_dir = "./input"
output_dir = "./output"
diagnostics_dir = "./diagnostics"
```
(hence all the changes to the files in the `example_cases` folder)

Each of the above dirs are divided into subdirs corresponding to each phase in the workflow
```
(base) brecinos@geos-l-0689:~/ice-stream-simple/output$ ls
- inversion
- forward
- eigendec
- error_prop
- inv_sigma
```
```
(base) brecinos@geos-l-0689:~/ice-stream-simple/diagnostics$ ls
- inversion
- forward
- eigendec
- error_prop
- inv_sigma
```
If you add a phase_suffix in **any** of the different phases in the toml e.g. add **phase_suffix** under -> [inversion], [time], [eigendec], [errorprop] and [invsigma]

A sub sub folder with that corresponding suffix will get added inside the folders defined above.
```
[inversion]

phase_suffix = 'only_alpha_inversion'

[time]

run_length = 0.2
#steps_per_year = 30
total_steps = 5
#dt = 0.033333333
num_sens = 6 #TODO rename

save_every_tstep = true
phase_suffix = '_num_sens_6_'
```
**in both in the diagnostics and output!** 
```
(base) brecinos@geos-l-0689:~/ice-stream-simple/output/forward$ ls
_num_sens_6_
```
```
(base) brecinos@geos-l-0689:~/ice-stream-simple/diagnostics/forward$ ls
_num_sens_6_
```


