### PR TITLE
taylor test outside of pytest

### DIFF
--- a/runs/run_taylor_fwd_inv.py
+++ b/runs/run_taylor_fwd_inv.py
@@ -50,25 +50,26 @@ def test_tv_run_forward(config_file):
     cntrl = slvr.get_control()
 
     slvr.reset_ts_zero()
-    J = slvr.timestep(adjoint_flag=1, qoi_func=qoi_func)[0]
+    J = slvr.timestep(adjoint_flag=1, qoi_func=qoi_func)[2]
     dJ = compute_gradient(J, cntrl)
 
     def forward_ts(cntrl, cntrl_init, name):
         slvr.reset_ts_zero()
         if (name == 'alpha'):
-            slvr._alpha = cntrl
+            slvr.set_control_fns([cntrl, slvr._beta], initial=True)
         elif (name == 'beta'):
-            slvr._beta = cntrl
+            slvr.set_control_fns([slvr._alpha, cntrl], initial=True)
         else:
             raise ValueError(f"Unrecognised cntrl name: {name}")
 
-        result = slvr.timestep(adjoint_flag=1, qoi_func=slvr.get_qoi_func())[0]
+        result = slvr.timestep(adjoint_flag=1, qoi_func=slvr.get_qoi_func())[2]
+        stop_manager()
 
         # Reset after simulation - confirmed necessary
         if (name == 'alpha'):
-            slvr._alpha = cntrl_init
+            slvr.set_control_fns([cntrl_init, slvr.beta], initial=True)
         elif (name == 'beta'):
-            slvr._beta = cntrl_init
+            slvr.set_control_fns([slvr._alpha, cntrl_init], initial=True)
         else:
             raise ValueError(f"Bad control name {name}")
 

--- a/runs/run_taylor_fwd_inv.py
+++ b/runs/run_taylor_fwd_inv.py
@@ -1,0 +1,99 @@
+# For fenics_ice copyright information see ACKNOWLEDGEMENTS in the fenics_ice
+# root directory
+
+# This file is part of fenics_ice.
+#
+# fenics_ice is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# fenics_ice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
+
+# This script does not output anything. It is only use for
+# running taylor test verification on the forward runs outside
+# of the pytest environment
+
+import os
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+
+import sys
+
+from runs import run_forward
+
+from fenics_ice.backend import clear_caches, compute_gradient, \
+    reset_manager, stop_manager, taylor_test
+
+def EQReset():
+    """Take care of tlm_adjoint EquationManager"""
+    # This prevents checkpointing errors when these run phases
+    # are tested after the stuff in test_model.py
+    reset_manager("memory")
+    clear_caches()
+    stop_manager()
+
+def test_tv_run_forward(config_file):
+
+    EQReset()
+
+    mdl_out = run_forward.run_forward(config_file)
+
+    slvr = mdl_out.solvers[0]
+
+    qoi_func = slvr.get_qoi_func()
+    cntrl = slvr.get_control()
+
+    slvr.reset_ts_zero()
+    J = slvr.timestep(adjoint_flag=1, qoi_func=qoi_func)[0]
+    dJ = compute_gradient(J, cntrl)
+
+    def forward_ts(cntrl, cntrl_init, name):
+        slvr.reset_ts_zero()
+        if (name == 'alpha'):
+            slvr._alpha = cntrl
+        elif (name == 'beta'):
+            slvr._beta = cntrl
+        else:
+            raise ValueError(f"Unrecognised cntrl name: {name}")
+
+        result = slvr.timestep(adjoint_flag=1, qoi_func=slvr.get_qoi_func())[0]
+
+        # Reset after simulation - confirmed necessary
+        if (name == 'alpha'):
+            slvr._alpha = cntrl_init
+        elif (name == 'beta'):
+            slvr._beta = cntrl_init
+        else:
+            raise ValueError(f"Bad control name {name}")
+
+        return result
+
+    cntrl_init = [f.copy(deepcopy=True) for f in cntrl]
+
+    seeds = {'alpha': 1e-2, 'beta': 1e-1}
+
+    for cntrl_curr, cntrl_curr_init, dJ_curr in zip(cntrl, cntrl_init, dJ):
+        min_order = taylor_test(lambda cntrl_val: forward_ts(cntrl_val,
+                                                             cntrl_curr_init,
+                                                             cntrl_curr.name()),
+                                cntrl_curr,
+                                J_val=J.value(),
+                                dJ=dJ_curr,
+                                seed=seeds[cntrl_curr.name()],
+                                M0=cntrl_curr_init,
+                                size=6)
+
+        print(f"Forward simulation cntrl: {cntrl_curr.name()} min_order: {min_order}")
+        print(min_order)
+        assert (min_order > 1.95)
+
+
+if __name__ == "__main__":
+    assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"
+    test_tv_run_forward(sys.argv[1])

--- a/runs/run_taylor_inv.py
+++ b/runs/run_taylor_inv.py
@@ -1,0 +1,99 @@
+# For fenics_ice copyright information see ACKNOWLEDGEMENTS in the fenics_ice
+# root directory
+
+# This file is part of fenics_ice.
+#
+# fenics_ice is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# fenics_ice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
+
+# This script does not output anything. It is only use for
+# running taylor test verification on the inversion outside
+# of the pytest environment
+
+import os
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+
+import sys
+from runs import run_inv
+from fenics_ice.backend import clear_caches, reset_manager, stop_manager,\
+    taylor_test_tlm, taylor_test_tlm_adjoint
+
+def EQReset():
+    """Take care of tlm_adjoint EquationManager"""
+    # This prevents checkpointing errors when these run phases
+    # are tested after the stuff in test_model.py
+    reset_manager("memory")
+    clear_caches()
+    stop_manager()
+
+def test_tv_run_inversion(config_file):
+
+    EQReset()
+
+    # Run the thing
+    mdl_out = run_inv.run_inv(config_file)
+
+    # Get expected values from the toml file
+    alpha_active = mdl_out.params.inversion.alpha_active
+    beta_active = mdl_out.params.inversion.beta_active
+
+    if alpha_active:
+        fwd_alpha = mdl_out.solvers[0].forward
+        alpha = mdl_out.solvers[0].alpha
+
+        min_order = taylor_test_tlm(fwd_alpha,
+                                    alpha,
+                                    tlm_order=1,
+                                    seed=1.0e-5)
+
+        assert (min_order > 1.95)
+
+        min_order = taylor_test_tlm_adjoint(fwd_alpha,
+                                            alpha,
+                                            adjoint_order=1,
+                                            seed=1.0e-5)
+
+        assert (min_order > 1.95)
+
+        min_order = taylor_test_tlm_adjoint(fwd_alpha,
+                                            alpha,
+                                            adjoint_order=2,
+                                            seed=1.0e-5)
+        assert (min_order > 1.95)
+
+    if beta_active:
+        fwd_beta = mdl_out.solvers[0].forward
+        beta = mdl_out.solvers[0].beta
+
+        min_order = taylor_test_tlm(fwd_beta,
+                                    beta,
+                                    tlm_order=1,
+                                    seed=1.0e-5)
+        assert (min_order > 1.95)
+
+        min_order = taylor_test_tlm_adjoint(fwd_beta,
+                                            beta,
+                                            adjoint_order=1,
+                                            seed=1.0e-5)
+        assert (min_order > 1.95)
+
+        min_order = taylor_test_tlm_adjoint(fwd_beta,
+                                            beta,
+                                            adjoint_order=2,
+                                            seed=1.0e-5)
+        assert (min_order > 1.95)
+
+
+if __name__ == "__main__":
+    assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"
+    test_tv_run_inversion(sys.argv[1])


### PR DESCRIPTION
Hello (cc. @jrmaddison, @dngoldberg )

I've added two new scripts under runs/ with the taylor test's that were before under the /test folder. 
When running the tv verification within pytest they both pass (inside pytest those tests are run only for ismipc_rc_1e6.toml ...) 

Outside of the pytest env only the inversion test [run_taylor_inv.py](https://github.com/bearecinos/fenics_ice/blob/taylor_test/runs/run_taylor_inv.py) passes for both ice-stream and ismipc. but I am not sure if I had set up the forward tv test correctly in [run_taylor_fwd_inv.py](https://github.com/bearecinos/fenics_ice/blob/taylor_test/runs/run_taylor_fwd_inv.py) fails with the following output:

```
/home/brecinos/tlm_adjoint/tlm_adjoint/verification.py:143: RuntimeWarning: invalid value encountered in true_divide
  orders_0 = np.log(error_norms_0[1:] / error_norms_0[:-1]) / np.log(0.5)
Error norms, no adjoint   = [0. 0. 0. 0. 0. 0.]
INFO:tlm_adjoint.verification:Error norms, no adjoint   = [0. 0. 0. 0. 0. 0.]
Orders,      no adjoint   = [nan nan nan nan nan]
INFO:tlm_adjoint.verification:Orders,      no adjoint   = [nan nan nan nan nan]
/home/brecinos/tlm_adjoint/tlm_adjoint/verification.py:150: RuntimeWarning: invalid value encountered in true_divide
  orders_1 = np.log(error_norms_1[1:] / error_norms_1[:-1]) / np.log(0.5)
Error norms, with adjoint = [0. 0. 0. 0. 0. 0.]
INFO:tlm_adjoint.verification:Error norms, with adjoint = [0. 0. 0. 0. 0. 0.]
Orders,      with adjoint = [nan nan nan nan nan]
INFO:tlm_adjoint.verification:Orders,      with adjoint = [nan nan nan nan nan]
Forward simulation cntrl: alpha min_order: nan
nan
Traceback (most recent call last):
  File "/home/brecinos/fenics_ice/runs//run_taylor_fwd_inv.py", line 99, in <module>
    test_tv_run_forward(sys.argv[1])
  File "/home/brecinos/fenics_ice/runs//run_taylor_fwd_inv.py", line 94, in test_tv_run_forward
    assert (min_order > 1.95)
AssertionError
```

This PR will remain as draft.

addressing issues #67 