### PR TITLE
change hardcoding of /tmp to tempfile.tempdir

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,12 +130,13 @@ def pytest_configure(config):
 
     # Clone the input data once even when test are run in parallel
     if rank == 0:
-        path_to_data = '/tmp/fenics_ice_test_data'
+        path_to_data = tempfile.gettempdir() + '/fenics_ice_test_data'
         if os.path.exists(path_to_data):
             pass
         else:
             subprocess.check_call(
-            ["git", "clone", "https://github.com/EdiGlacUQ/fenics_ice_test_data.git", "/tmp/fenics_ice_test_data"])
+            ["git", "clone", "https://github.com/EdiGlacUQ/fenics_ice_test_data.git", \
+               tempfile.gettempdir() + '/fenics_ice_test_data'])
     else:
         pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,8 +135,7 @@ def pytest_configure(config):
             pass
         else:
             subprocess.check_call(
-            ["git", "clone", "https://github.com/EdiGlacUQ/fenics_ice_test_data.git", \
-               tempfile.gettempdir() + '/fenics_ice_test_data'])
+            ["git", "clone", "https://github.com/EdiGlacUQ/fenics_ice_test_data.git",path_to_data])
     else:
         pass
 


### PR DESCRIPTION
This is a test to fix a potential issue with pytest. /tmp is given in 2 places in tests/conftest.py as the cloning location of fenics_ice_test_data, but on line 37, tempfile.get_tempdir() is used -- which is based on the TMPDIR env variable, if set. This can be of value in the instance that /tmp contains folders created by others which cannot be overwritten.

I have changed all /tmp to tempfile.get_tempdir(). I have made this PR in the main repo to make it easier to test with github actions -- all seems OK.