### PR TITLE
Update handling of static functions

### DIFF
--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -541,7 +541,7 @@ class InputData(object):
         name : the variable to be interpolated (need not necessarily exist!)
         space : function space onto which to interpolate
         default : value to return if field is absent (otherwise raise error)
-        static : if True, set _Function_static__ = True to save always-zero differentials
+        static : if True, declare the result to be static
         method: "nearest" or "linear"
 
         Returns:

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -393,8 +393,6 @@ class model:
         fl_ex = conditional(H <= H_flt, 1.0, 0.0)
 
         self.surf = project((1-fl_ex)*(bed+H) + (fl_ex)*H*(1-rhoi/rhow), self.Q)
-        self.surf._Function_static__ = True
-        self.surf._Function_checkpoint__ = False
         self.surf.rename("surf", "")
 
     def bdrag_to_alpha(self, B2):

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -133,7 +133,9 @@ class model:
         beta = project(self.bglen_to_beta(A**(-1.0/n)), self.Qp)
 
         self.beta.assign(beta)
+        function_update_state(self.beta)
         self.beta_bgd.assign(beta)
+        function_update_state(self.beta_bgd)
 
     def def_lat_dirichletbc(self):
         """Homogenous dirichlet conditions on lateral boundaries"""
@@ -146,6 +148,7 @@ class model:
     def alpha_from_data(self):
         """Get alpha field from initial input data (run_momsolve only)"""
         self.alpha.assign(self.input_data.interpolate("alpha", self.Qp))
+        function_update_state(self.alpha)
 
     def bglen_from_data(self, mask_only=False):
         """Get bglen field from initial input data"""
@@ -192,6 +195,7 @@ class model:
                       str(outdir/inversion_file),
                       'r') as infile:
             infile.read(self.alpha, 'alpha')
+            function_update_state(self.alpha)
 
     def beta_from_inversion(self):
         """Get beta field from inversion step"""
@@ -209,8 +213,10 @@ class model:
                       str(outdir/inversion_file),
                       'r') as infile:
             infile.read(self.beta, 'beta')
+            function_update_state(self.beta)
 
         self.beta_bgd.assign(self.beta)
+        function_update_state(self.beta_bgd)
 
     def init_beta(self, beta, pert=False):
         """
@@ -222,7 +228,9 @@ class model:
 
         beta_proj = project(beta, self.Qp)
         self.beta.assign(beta_proj)
+        function_update_state(self.beta)
         self.beta_bgd.assign(beta_proj)
+        function_update_state(self.beta_bgd)
 
         # TODO - tidy this up properly (remove pert arg)
         # if pert:
@@ -231,6 +239,7 @@ class model:
         #     pert_vec = 0.001*bv*randn(bv.size)
         #     self.beta.vector().set_local(bv + pert_vec)
         #     self.beta.vector().apply('insert')
+        #     function_update_state(self.beta)
 
 
     def vel_obs_from_data(self):
@@ -474,6 +483,7 @@ class model:
             self.alpha.vector().apply('insert')
         else:
             raise NotImplementedError(f"Don't have code for method {method}")
+        function_update_state(self.alpha)
 
         write_diag = self.params.io.write_diagnostics
         if write_diag:

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -211,6 +211,7 @@ class ssa_solver:
             if initial:
                 assert len(f) == 2
                 self._cntrl_assigner.assign(self._alphaXbeta, f)
+                function_update_state(self._alphaXbeta)
             else:
                 assert len(f) == 1
                 self._alphaXbeta = f[0]
@@ -220,7 +221,9 @@ class ssa_solver:
             if initial:
                 assert len(f) == 2
                 self._alpha.assign(f[0])
+                function_update_state(self._alpha)
                 self._beta.assign(f[1])
+                function_update_state(self._beta)
             elif invconfig.dual:
                 assert len(f) == 2
                 self._alpha = f[0]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -17,7 +17,7 @@
 
 # -*- coding: utf-8 -*-
 
-from fenics_ice.backend import Function, norm
+from fenics_ice.backend import Function, function_update_state, norm
 
 import pytest
 import os
@@ -209,8 +209,10 @@ def test_control_separation(request, setup_deps, temp_model):
 
     slvr.alpha.vector()[:] = 1e3
     slvr.alpha.vector().apply("insert")
+    function_update_state(slvr.alpha)
     slvr.beta.vector()[:] = 1e3
     slvr.beta.vector().apply("insert")
+    function_update_state(slvr.beta)
 
     with pytest.raises(AttributeError):
         slvr.beta = 1.0


### PR DESCRIPTION
Functions marked 'static' should have their state marked as updated if edited, so that caches can be invalidated. tlm_adjoint performs some state updates (and should perhaps perform more). This PR adds some defensive state updates in fenics_ice.

Also `Function._Function__static` and `Function._Function__checkpoint` attributes no longer have any effect -- remove associated code and update a docstring.