### PR TITLE
Minor updates to eigendecomposition code

### DIFF
--- a/fenics_ice/decorators.py
+++ b/fenics_ice/decorators.py
@@ -62,16 +62,3 @@ def timer(func):
         return value
 
     return wrapper_timer
-
-
-# Note - copied from tlm_adjoint eigendecompose.py
-flagged_error = [False]
-def flag_errors(fn):
-    """Catch errors in python routines which PETSc otherwise ignores"""
-    def wrapped_fn(*args, **kwargs):
-        try:
-            return fn(*args, **kwargs)
-        except:  # noqa: E722
-            flagged_error[0] = True
-            raise
-    return wrapped_fn

--- a/fenics_ice/eigendecomposition.py
+++ b/fenics_ice/eigendecomposition.py
@@ -15,7 +15,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with fenics_ice.  If not, see <https://www.gnu.org/licenses/>.
 
-#!/usr/bin/env python
+# Contains code derived from eigendecomposition code from tlm_adjoint. The
+# original tlm_adjoint 'eigendecompose' function loosely follows the slepc4py
+# 3.6.0 demo demo/ex3.py. slepc4py 3.6.0 license information follows.
+#
 # =========================
 # LICENSE: SLEPc for Python
 # =========================
@@ -56,13 +59,13 @@ from .backend import HDF5File, XDMFFile, function_get_values, \
 
 from . import prior
 
-import pickle
-import numpy as np
-import petsc4py.PETSc as PETSc
-from pathlib import Path
-import os
+import functools
 import logging
-from IPython import embed
+import numpy as np
+from pathlib import Path
+import pickle
+
+import petsc4py.PETSc as PETSc
 
 log = logging.getLogger("fenics_ice")
 
@@ -81,10 +84,11 @@ _flagged_error = [False]
 
 
 def flag_errors(fn):
+    @functools.wraps(fn)
     def wrapped_fn(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except:  # noqa: E722
+        except Exception:
             _flagged_error[0] = True
             raise
     return wrapped_fn
@@ -112,7 +116,7 @@ class PythonMatrix:
 
 def eigendecompose(space, A_action, B_matrix=None, N_eigenvalues=None,
                    solver_type=None, problem_type=None, which=None,
-                   tolerance=1.0e-12, max_it=1e6, configure=None, monitor=None):
+                   tolerance=1.0e-12, max_it=1000000, configure=None, monitor=None):
     # First written 2018-03-01
     """
     Matrix-free interface with SLEPc via slepc4py, loosely following
@@ -121,11 +125,10 @@ def eigendecompose(space, A_action, B_matrix=None, N_eigenvalues=None,
 
     Arguments:
 
-    space          Eigenspace.
-    A_action       Function handle accepting a function and returning a
-                   function or NumPy array, defining the action of the
-                   left-hand-side matrix, e.g. as returned by
-                   Hessian.action_fn.
+    space          Eigenvector space.
+    A_action       Callable accepting a function and returning a function or
+                   NumPy array, defining the action of the left-hand-side
+                   matrix, e.g. as returned by Hessian.action_fn.
     B_matrix       (Optional) Right-hand-side matrix in a generalized
                    eigendecomposition.
     N_eigenvalues  (Optional) Number of eigenvalues to attempt to find.
@@ -145,9 +148,7 @@ def eigendecompose(space, A_action, B_matrix=None, N_eigenvalues=None,
 
     Returns:
 
-    A tuple (lam, V_r) for Hermitian problems, or (lam, (V_r, V_i)) otherwise,
-    where lam is an array of eigenvalues, and V_r / V_i are tuples of functions
-    containing the real and imaginary parts of the corresponding eigenvectors.
+    A SLEPc.EPS.
     """
 
     import slepc4py.SLEPc as SLEPc
@@ -204,13 +205,9 @@ def eigendecompose(space, A_action, B_matrix=None, N_eigenvalues=None,
 
     return esolver
 
+
 def test_eigendecomposition(esolver, results, space, params):
     """Check the consistency of the eigendecomposition"""
-
-    # How many EVs?
-    num_eig = params.eigendec.num_eig
-    N = function_global_size(space_new(space))
-    N_ev = N if num_eig is None else num_eig
 
     A_matrix, _ = esolver.getOperators()
 
@@ -229,6 +226,7 @@ def test_eigendecomposition(esolver, results, space, params):
     lam_diff = (lam - np.roll(lam, -1))[:-1]
     if not np.all(lam_diff > (esolver_tol**2.0)):
         log.warning("Eigenvalues are not unique!")
+
 
 def slepc_config_callback(reg_op, prior_action, space):
     """Closure to define the slepc config callback"""
@@ -265,6 +263,7 @@ def slepc_config_callback(reg_op, prior_action, space):
 
     return inner_fn
 
+
 def slepc_monitor_callback(params, space, result_list):
     """
     Closure which defines the slepc monitor callback
@@ -295,7 +294,7 @@ def slepc_monitor_callback(params, space, result_list):
     ev_filepath = outdir / eigenvecs_file
     # Delete files to avoid append
     ev_filepath.unlink(missing_ok=True)
-    p = diagdir/ eigenvecs_file
+    p = diagdir / eigenvecs_file
     ev_xdmf_filepath = Path(p).parent / Path(p.stem + "_vis").with_suffix(".xdmf")
 
     ev_xdmf_file = XDMFFile(space.mesh().mpi_comm(), str(ev_xdmf_filepath))
@@ -376,6 +375,7 @@ def slepc_monitor_callback(params, space, result_list):
         log.info("Done with monitor")
 
     return inner_fn
+
 
 def ev_resid(esolver, V_r, lam):
     """Given a function V_r, what is the residual norm, i.e. norm(A V_r - lambda B V_r)"""

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -18,9 +18,11 @@
 from .backend import Constant, Function, KrylovSolver, TestFunctions, \
     TrialFunctions, Vector, assemble, dx, grad, inner, solve
 
-import ufl
-from .decorators import count_calls, timer, flag_errors
+from .decorators import count_calls, timer
+from .eigendecomposition import flag_errors
+
 from abc import ABC, abstractmethod
+import ufl
 
 class Prior(ABC):
     """Abstraction for prior used by both comp_J_inv and run_eigendec.py"""
@@ -355,7 +357,6 @@ class LaplacianPC:
     i.e. B^-1  =  L^-1 M L^-1
     """
 
-    @flag_errors
     def __init__(self, lap):
         self.laplacian = lap
         self.action = self.laplacian.inv_action

--- a/runs/run_eigendec.py
+++ b/runs/run_eigendec.py
@@ -31,14 +31,14 @@ import datetime
 
 # assure we're not using tlm_adjoint version
 from fenics_ice.eigendecomposition import eigendecompose
-from fenics_ice.eigendecomposition import PythonMatrix, slepc_monitor_callback, slepc_config_callback
+from fenics_ice.eigendecomposition import slepc_monitor_callback, slepc_config_callback
 import fenics_ice.eigendecomposition as ED
 
 from fenics_ice import model, solver, prior, inout
 
 from fenics_ice import mesh as fice_mesh
 from fenics_ice.config import ConfigParser
-from fenics_ice.decorators import count_calls, timer, flagged_error
+from fenics_ice.decorators import count_calls, timer
 
 import numpy as np
 import matplotlib as mpl
@@ -126,7 +126,7 @@ def run_eigendec(config_file):
     eig_algo = params.eigendec.eig_algo
     if eig_algo == "slepc":
 
-        assert not flagged_error[0]
+        assert not ED._flagged_error[0]
 
         results = {}  # Create this empty dict & pass it to slepc_monitor_callback to fill
         # Eigendecomposition
@@ -145,10 +145,7 @@ def run_eigendec(config_file):
         vr = results['vr']
         lam = results['lam']
 
-        if flagged_error[0]:
-            # Note: I have been unable to confirm that this does anything in my setup
-            # Python errors within LaplacianPC seem to be raised even without the
-            # @flag_errors decorator.
+        if ED._flagged_error[0]:
             raise Exception("Python errors in eigendecomposition preconditioner.")
 
         # Check the eigenvectors & eigenvalues

--- a/runs/run_eigendec.py
+++ b/runs/run_eigendec.py
@@ -125,9 +125,6 @@ def run_eigendec(config_file):
     # Hessian eigendecomposition using SLEPSc
     eig_algo = params.eigendec.eig_algo
     if eig_algo == "slepc":
-
-        assert not ED._flagged_error[0]
-
         results = {}  # Create this empty dict & pass it to slepc_monitor_callback to fill
         # Eigendecomposition
         import slepc4py.SLEPc as SLEPc
@@ -144,9 +141,6 @@ def run_eigendec(config_file):
         log.info("Finished eigendecomposition")
         vr = results['vr']
         lam = results['lam']
-
-        if ED._flagged_error[0]:
-            raise Exception("Python errors in eigendecomposition preconditioner.")
 
         # Check the eigenvectors & eigenvalues
         if(params.eigendec.test_ed):


### PR DESCRIPTION
- Bugfix to use of `flag_errors` decorator -- a single decorator should be defined and used. Minor updates to the decorator.
- `max_it` argument to `eigendecompose` should be an integer.
- Note tlm_adjoint origin in eigendecomposition.py.
- Minor updates to `eigendecompose` docstring.
- flake8 fixes.