### PR TITLE
Branch sample post and prior

### DIFF
--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -255,6 +255,10 @@ class SampleCfg(ConfigPrinter):
     sample_size: int = 1
     sample_alpha: bool = False
     sample_beta: bool = False
+    sample_posterior: bool = False
+    # this is to do nothing right now -- but it might be more efficient to create interactive plots
+    # interactive_plot: bool = False
+    num_eigenvals: int = 0
     phase_name: str = 'sample'
     phase_suffix: str = ''
 

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -108,7 +108,7 @@ class ConfigParser(object):
 
         # Optional section for sampling prior and posterior
         try:
-            sample_dict = SampleCfg(**self.config_dict['sample'])
+            sample_dict = self.config_dict['sample']
         except KeyError:
             sample_dict = {}
         self.sample = SampleCfg(**sample_dict)

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -85,7 +85,6 @@ class ConfigParser(object):
         self.obs = ObsCfg(**self.config_dict['obs'])
         self.error_prop = ErrorPropCfg(**self.config_dict['errorprop'])
         self.eigendec = EigenDecCfg(**self.config_dict['eigendec'])
-        self.sample = SampleCfg(**self.config_dict['sample'])
 
         # Optional melt section
         try:
@@ -106,6 +105,13 @@ class ConfigParser(object):
         except KeyError:
             cpoint_dict = {}
         self.checkpointing = CheckpointCfg(**cpoint_dict)
+
+        # Optional section for sampling prior and posterior
+        try:
+            sample_dict = SampleCfg(**self.config_dict['sample'])
+        except KeyError:
+            sample_dict = {}
+        self.sample = SampleCfg(**sample_dict)
 
         try:  # Optional BC list
             self.bcs = [BCCfg(**bc) for bc in self.config_dict['BC']]

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -85,6 +85,7 @@ class ConfigParser(object):
         self.obs = ObsCfg(**self.config_dict['obs'])
         self.error_prop = ErrorPropCfg(**self.config_dict['errorprop'])
         self.eigendec = EigenDecCfg(**self.config_dict['eigendec'])
+        self.sample = SampleCfg(**self.config_dict['sample'])
 
         # Optional melt section
         try:
@@ -244,6 +245,17 @@ class ErrorPropCfg(ConfigPrinter):
     """
     qoi: str = 'vaf'
     phase_name: str = 'error_prop'
+    phase_suffix: str = ''
+
+@dataclass(frozen=True)
+class SampleCfg(ConfigPrinter):
+    """
+    Configuration related to error propagation
+    """
+    sample_size: int = 1
+    sample_alpha: bool = False
+    sample_beta: bool = False
+    phase_name: str = 'sample'
     phase_suffix: str = ''
 
 @dataclass(frozen=True)

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -20,6 +20,8 @@ from .backend import Constant, Function, KrylovSolver, TestFunctions, \
 
 from .decorators import count_calls, timer
 from .eigendecomposition import flag_errors
+from fenics_ice.sqrt_matrix_action import A_root_action
+
 
 from abc import ABC, abstractmethod
 import ufl

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -86,6 +86,7 @@ class Prior(ABC):
         self.A.init_vector(self.tmp1, 0)
         self.A.init_vector(self.tmp2, 1)
 
+        # preconditioned solver object to find square root of mass matrix (not used)
         self.lumpedPCMassSolver = LumpedPCSqrtMassAction(space=self.space, tol=1.0e-16)
 
     def placeholder_fn(self, name, idx):
@@ -303,8 +304,7 @@ class Laplacian(Prior):
                                 #                  L M-1 L L-1 M1/2
                                 #                  L M-1 M1/2
         M_norm = self.M.norm("linf")
-#        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
-        tmp1, terms = self.lumpedPCMassSolver.action(x)
+        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
         self.M_solver.solve(self.tmp2, self.tmp1) 
         self.A.mult(self.tmp2,self.tmp3)
         y.set_local(self.tmp3.get_local())
@@ -313,8 +313,7 @@ class Laplacian(Prior):
     def sqrt_inv_action(self,x,y):  # sqrt of inv cov: Gamma 1/2
                                     #                  L-1 M1/2
         M_norm = self.M.norm("linf")        
-#        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
-        tmp1, terms = self.lumpedPCMassSolver.action(x)
+        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
         self.A_solver.solve(self.tmp2, self.tmp1)
         y.set_local(self.tmp2.get_local())
         y.apply("insert")

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -82,7 +82,7 @@ class Prior(ABC):
         self.construct_mass_operator()
         self.construct_prior_operator()
 
-        self.tmp1, self.tmp2, self.tmp3 = Vector(), Vector(), Vector()
+        self.tmp1, self.tmp2 = Vector(), Vector()
         self.A.init_vector(self.tmp1, 0)
         self.A.init_vector(self.tmp2, 1)
 
@@ -144,7 +144,6 @@ class Prior(ABC):
                                          "relative_tolerance": 1.0e-14})
         self.A_solver.set_operator(self.A)
 
-        # self.tmp1, self.tmp2 = Function(self.space), Function(self.space)
         self.tmp1, self.tmp2 = Vector(), Vector()
         self.A.init_vector(self.tmp1, 0)
         self.A.init_vector(self.tmp2, 1)
@@ -303,22 +302,14 @@ class Laplacian(Prior):
     def sqrt_action(self,x,y):  # sqrt of inv cov: Gamma -1 Gamma 1/2
                                 #                  L M-1 L L-1 M1/2
                                 #                  L M-1 M1/2
-        M_norm = self.M.norm("linf")
-#        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
         self.tmp1, terms = self.lumpedPCMassSolver.action(x)
         self.M_solver.solve(self.tmp2, self.tmp1) 
-        self.A.mult(self.tmp2,self.tmp3)
-        y.set_local(self.tmp3.get_local())
-        y.apply("insert")
+        self.A.mult(self.tmp2,y)
 
     def sqrt_inv_action(self,x,y):  # sqrt of inv cov: Gamma 1/2
                                     #                  L-1 M1/2
-        M_norm = self.M.norm("linf")        
-#        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
         self.tmp1, terms = self.lumpedPCMassSolver.action(x)
-        self.A_solver.solve(self.tmp2, self.tmp1)
-        y.set_local(self.tmp2.get_local())
-        y.apply("insert")
+        self.A_solver.solve(y, self.tmp1)
 
 class Laplacian_flt(Laplacian):
     """

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -289,6 +289,23 @@ class Laplacian(Prior):
         y.set_local(self.tmp1.get_local())
         y.apply("insert")
 
+    def sqrt_action(self,x,y):  # sqrt of inv cov: Gamma -1 Gamma 1/2
+                                #                  L M-1 L L-1 M1/2
+                                #                  L M-1 M1/2
+        M_norm = self.M.norm("linf")
+        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm)
+        self.M_solver.solve(self.tmp2, self.tmp1) 
+        self.A.mult(self.tmp2,self.tmp3)
+        y.set_local(self.tmp3.get_local())
+        y.apply("insert")
+
+    def sqrt_inv_action(self,x,y):  # sqrt of inv cov: Gamma 1/2
+                                    #                  L-1 M1/2
+        M_norm = self.M.norm("linf")        
+        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm)
+        self.A_solver.solve(self.tmp2, self.tmp1)
+        y.set_local(self.tmp2.get_local())
+        y.apply("insert")
 
 class Laplacian_flt(Laplacian):
     """

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -87,7 +87,7 @@ class Prior(ABC):
         self.A.init_vector(self.tmp2, 1)
 
         # preconditioned solver object to find square root of mass matrix (not used)
-        self.lumpedPCMassSolver = LumpedPCSqrtMassAction(space=self.space, tol=1.0e-16)
+        self.lumpedPCMassSolver = LumpedPCSqrtMassAction(space=self.space, tol=1.0e-16, beta=2.0/3.0)
 
     def placeholder_fn(self, name, idx):
         """
@@ -304,7 +304,8 @@ class Laplacian(Prior):
                                 #                  L M-1 L L-1 M1/2
                                 #                  L M-1 M1/2
         M_norm = self.M.norm("linf")
-        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
+#        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
+        self.tmp1, terms = self.lumpedPCMassSolver.action(x)
         self.M_solver.solve(self.tmp2, self.tmp1) 
         self.A.mult(self.tmp2,self.tmp3)
         y.set_local(self.tmp3.get_local())
@@ -313,7 +314,8 @@ class Laplacian(Prior):
     def sqrt_inv_action(self,x,y):  # sqrt of inv cov: Gamma 1/2
                                     #                  L-1 M1/2
         M_norm = self.M.norm("linf")        
-        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
+#        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
+        self.tmp1, terms = self.lumpedPCMassSolver.action(x)
         self.A_solver.solve(self.tmp2, self.tmp1)
         y.set_local(self.tmp2.get_local())
         y.apply("insert")

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -301,7 +301,6 @@ class Laplacian(Prior):
                                 #                  L M-1 L L-1 M1/2
                                 #                  L M-1 M1/2
         M_norm = self.M.norm("linf")
-        print(M_norm)
         self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
         self.M_solver.solve(self.tmp2, self.tmp1) 
         self.A.mult(self.tmp2,self.tmp3)
@@ -311,7 +310,6 @@ class Laplacian(Prior):
     def sqrt_inv_action(self,x,y):  # sqrt of inv cov: Gamma 1/2
                                     #                  L-1 M1/2
         M_norm = self.M.norm("linf")        
-        print(M_norm)
         self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
         self.A_solver.solve(self.tmp2, self.tmp1)
         y.set_local(self.tmp2.get_local())

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -86,7 +86,7 @@ class Prior(ABC):
         self.A.init_vector(self.tmp1, 0)
         self.A.init_vector(self.tmp2, 1)
 
-        lumpedPCMassSolver = LumpedPCSqrtMassAction(space=self.space, tol=1.0e-16)
+        self.lumpedPCMassSolver = LumpedPCSqrtMassAction(space=self.space, tol=1.0e-16)
 
     def placeholder_fn(self, name, idx):
         """
@@ -304,7 +304,7 @@ class Laplacian(Prior):
                                 #                  L M-1 M1/2
         M_norm = self.M.norm("linf")
 #        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
-        tmp1, terms = lumpedPCMassSolver.action(x)
+        tmp1, terms = self.lumpedPCMassSolver.action(x)
         self.M_solver.solve(self.tmp2, self.tmp1) 
         self.A.mult(self.tmp2,self.tmp3)
         y.set_local(self.tmp3.get_local())
@@ -314,7 +314,7 @@ class Laplacian(Prior):
                                     #                  L-1 M1/2
         M_norm = self.M.norm("linf")        
 #        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
-        tmp1, terms = lumpedPCMassSolver.action(x)
+        tmp1, terms = self.lumpedPCMassSolver.action(x)
         self.A_solver.solve(self.tmp2, self.tmp1)
         y.set_local(self.tmp2.get_local())
         y.apply("insert")

--- a/fenics_ice/prior.py
+++ b/fenics_ice/prior.py
@@ -82,6 +82,10 @@ class Prior(ABC):
         self.construct_mass_operator()
         self.construct_prior_operator()
 
+        self.tmp1, self.tmp2, self.tmp3 = Vector(), Vector(), Vector()
+        self.A.init_vector(self.tmp1, 0)
+        self.A.init_vector(self.tmp2, 1)
+
     def placeholder_fn(self, name, idx):
         """
         Generate placeholder functions
@@ -297,7 +301,8 @@ class Laplacian(Prior):
                                 #                  L M-1 L L-1 M1/2
                                 #                  L M-1 M1/2
         M_norm = self.M.norm("linf")
-        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm)
+        print(M_norm)
+        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
         self.M_solver.solve(self.tmp2, self.tmp1) 
         self.A.mult(self.tmp2,self.tmp3)
         y.set_local(self.tmp3.get_local())
@@ -306,7 +311,8 @@ class Laplacian(Prior):
     def sqrt_inv_action(self,x,y):  # sqrt of inv cov: Gamma 1/2
                                     #                  L-1 M1/2
         M_norm = self.M.norm("linf")        
-        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm)
+        print(M_norm)
+        self.tmp1, terms = A_root_action(self.M, x, tol=1.0e-16, beta=M_norm, max_terms=100000)
         self.A_solver.solve(self.tmp2, self.tmp1)
         y.set_local(self.tmp2.get_local())
         y.apply("insert")

--- a/fenics_ice/sqrt_matrix_action.py
+++ b/fenics_ice/sqrt_matrix_action.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from fenics import TestFunction, TrialFunction, assemble, dx, inner
-
+from fenics import TestFunction, TrialFunction, assemble, dx, inner, split
+import ufl
 import numpy as np
 
 __all__ = \
@@ -89,7 +89,8 @@ class LumpedPCSqrtMassAction:
         """
 
         test = TestFunction(space)
-        M_L = assemble(test * dx)
+        M_L = assemble(sum(split(test), ufl.zero()) * dx) 
+        #M_L = assemble(test * dx)
 
         if M is None:
             trial = TrialFunction(space)

--- a/fenics_ice/sqrt_matrix_action.py
+++ b/fenics_ice/sqrt_matrix_action.py
@@ -90,7 +90,6 @@ class LumpedPCSqrtMassAction:
 
         test = TestFunction(space)
         M_L = assemble(sum(split(test), ufl.zero()) * dx) 
-        #M_L = assemble(test * dx)
 
         if M is None:
             trial = TrialFunction(space)

--- a/fenics_ice/sqrt_matrix_action.py
+++ b/fenics_ice/sqrt_matrix_action.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from fenics import TestFunction, TrialFunction, assemble, dx, inner
+
+import numpy as np
+
+__all__ = \
+    [
+        "A_root_action",
+        "LumpedPCSqrtMassAction",
+        "RootActionException"
+    ]
+
+
+class RootActionException(Exception):
+    pass
+
+
+def A_root_action(A, x, tol, beta=1.0, max_terms=1000):
+    """
+    Compute the action of the principal square root of the symmetric positive
+    definite matrix A, as in
+      N. J. Higham, "Functions of Matrices: Theory and Computation", SIAM,
+      2008, (6.38)
+    Arguments:
+      A          A Matrix, or a callable of the form
+                     def A(x):
+                 where x is a Vector, returning A x as a Vector.
+      x          Matrix action direction.
+      tol        Absolute tolerance. Positive float.
+      beta       Compute sqrt{beta} (A / beta)^{1/2} (s in Higham 2008
+                 equation (6.39)). Positive float.
+      max_its    Maximum number of terms in the binomial expansion. Integer,
+                 >= 2.
+    Returns:
+      y, terms
+    where y is a Vector containing the action, and terms is the number of
+    terms added.
+    """
+
+    if callable(A):
+        A_action = A
+    else:
+        def A_action(x):
+            return A * x
+
+    y = x.copy()
+    z = x.copy()
+    alpha = [1, 2]
+
+    j = 1
+    while True:
+        z.axpy(-1.0 / beta, A_action(z))
+        change = y.copy()
+        y.axpy(-alpha[0] / alpha[1], z)
+        if np.isnan(y.sum()):
+            raise RootActionException("NaN encountered")
+        change.axpy(-1.0, y)
+        change_norm = change.norm("linf") * np.sqrt(beta)
+        # print(f"terms {j + 1:d}, norm = {change_norm:.6e}")
+        if change_norm < tol:
+            break
+        j += 1
+        if j >= max_terms:
+            raise RootActionException("Maximum terms exceeded")
+        alpha[0] *= 2 * j - 3
+        alpha[1] *= 2 * j
+
+    return y * np.sqrt(beta), j + 1
+
+
+class LumpedPCSqrtMassAction:
+    def __init__(self, space, tol, beta=1.0, M=None):
+        """
+        Class for the calculation of matrix actions
+            A x,
+        where
+            A = M_L^{1/2} (M_L^{-1/2} M M_L^{-1/2})^{1/2},
+        so that
+            A A^T = M,
+        where M is the mass matrix and M_L the row-summed lumped mass matrix.
+        The square root of M_L^{-1/2} M M_L^{-1/2} is computed using
+        A_root_action.
+        Arguments:
+            space      The function space.
+            tol, beta  As for A_root_action.
+            M          (Optional) Mass matrix.
+        """
+
+        test = TestFunction(space)
+        M_L = assemble(test * dx)
+
+        if M is None:
+            trial = TrialFunction(space)
+            M = assemble(inner(trial, test) * dx)
+
+        sqrt_M_L = M_L.copy()
+        sqrt_M_L.set_local(np.sqrt(M_L.get_local()))
+        sqrt_M_L.apply("insert")
+
+        sqrt_M_L_inv = M_L.copy()
+        sqrt_M_L_inv.set_local(1.0 / np.sqrt(M_L.get_local()))
+        sqrt_M_L_inv.apply("insert")
+
+        self._tol = tol
+        self._beta = beta
+        self._M = M
+        self._sqrt_M_L = sqrt_M_L
+        self._sqrt_M_L_inv = sqrt_M_L_inv
+
+    def action(self, x):
+        """
+        Compute.
+            A x,
+        where
+            A = M_L^{1/2} (M_L^{-1/2} M M_L^{-1/2})^{1/2},
+        so that
+            A A^T = M.
+        Arguments:
+            x  The matrix action direction.
+        Returns:
+          y, terms
+        where y is a Vector containing the action, and terms is the number of
+        terms added in A_root_action.
+        """
+
+        def transformed_M_action(x):
+            return self._sqrt_M_L_inv * (self._M * (self._sqrt_M_L_inv * x))
+
+        y, terms = A_root_action(transformed_M_action, x, tol=self._tol,
+                                 beta=self._beta)
+        y = self._sqrt_M_L * y
+        return y, terms
+
+    def inverse_action(self, x, solver):
+        """
+        Compute.
+            B x,
+        where
+            B = M^{-1} A,
+            A = M_L^{1/2} (M_L^{-1/2} M M_L^{-1/2})^{1/2},
+        so that
+            B B^T = M^{-1}.
+        Arguments:
+            x       Vector. The matrix action direction.
+            solver  Linear solver, used to solve for y in
+                        M y = A x.
+        Returns:
+          y, terms
+        where y is a Vector containing the action, and terms is the number of
+        terms added in A_root_action.
+        """
+
+        y_, terms = self.action(x)
+        y = y_.copy()
+        solver.solve(y, y_)
+        return y, terms

--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -73,8 +73,6 @@ def run_sample(config_file):
     if len(phase_suffix_e) > 0:
         lamfile = params.io.run_name + phase_suffix_e + '_eigvals.p'
         vecfile = params.io.run_name + phase_suffix_e + '_vr.h5'
-#    if len(phase_suffix_qoi) > 0:
-#        dqoi_h5file = params.io.run_name + phase_suffix_qoi + '_dQ_ts.h5'
 
     # Get model mesh
     mesh = fice_mesh.get_mesh(params)
@@ -97,197 +95,197 @@ def run_sample(config_file):
     Prior = mdl.get_prior()
     reg_op = Prior(slvr, space)
 
-#    x, y, z = [Function(space) for i in range(3)]
-    y = Function(space)
-
     if (sample_posterior):
 
-      # Loads eigenvalues from file
-      outdir_e = Path(outdir)/phase_name_e/phase_suffix_e
-      with open(outdir_e/lamfile, 'rb') as ff:
-          eigendata = pickle.load(ff)
-          lam = eigendata[0].real.astype(np.float64)
-          nlam = len(lam)
+        # Loads eigenvalues from file
+        outdir_e = Path(outdir)/phase_name_e/phase_suffix_e
+        with open(outdir_e/lamfile, 'rb') as ff:
+            eigendata = pickle.load(ff)
+            lam = eigendata[0].real.astype(np.float64)
+            nlam = len(lam)
 
 
-      # Check if eigendecomposition successfully produced num_eig
-      # or if some are NaN
-      if np.any(np.isnan(lam)):
-          nlam = np.argwhere(np.isnan(lam))[0][0]
-          lam = lam[:nlam]
+        # Check if eigendecomposition successfully produced num_eig
+        # or if some are NaN
+        if np.any(np.isnan(lam)):
+            nlam = np.argwhere(np.isnan(lam))[0][0]
+            lam = lam[:nlam]
 
-      # and eigenvectors from .h5 file
-      eps = params.constants.float_eps
-      W = []
+        # and eigenvectors from .h5 file
+        eps = params.constants.float_eps
+        W = []
 
-      max_lam = params.sample.num_eigenvals
-      if (max_lam > 0):
-          lam = lam[:max_lam] 
+        max_lam = params.sample.num_eigenvals
+        if (max_lam > 0):
+            lam = lam[:max_lam] 
 
-      with HDF5File(MPI.comm_world, str(outdir_e/vecfile), 'r') as hdf5data:
-          for i in range(len(lam)):
-              w = Function(space)
-              hdf5data.read(w, f'v/vector_{i}')
+        y = Function(space)
+        with HDF5File(MPI.comm_world, str(outdir_e/vecfile), 'r') as hdf5data:
+            for i in range(len(lam)):
+                w = Function(space)
+                hdf5data.read(w, f'v/vector_{i}')
 
-              # Test norm in prior == 1.0
-              reg_op.action(w.vector(), y.vector())
-              norm_in_prior = w.vector().inner(y.vector())
-              assert (abs(norm_in_prior - 1.0) < eps)
+                # Test norm in prior == 1.0
+                reg_op.action(w.vector(), y.vector())
+                norm_in_prior = w.vector().inner(y.vector())
+                assert (abs(norm_in_prior - 1.0) < eps)
 
-              W.append(w)
+                W.append(w)
 
 
       # take only the largest eigenvalues
-      pind = np.flatnonzero(lam > threshlam)
-      lam = lam[pind]
-      nlam = len(lam)
-      W = [W[i] for i in pind]
+        pind = np.flatnonzero(lam > threshlam)
+        lam = lam[pind]
+        nlam = len(lam)
+        W = [W[i] for i in pind]
 
 ### ABOVE THIS POINT CODE IS BORROWED FROM RUN_ERRORPROP.PY
 
-      D = np.diag(1 / np.sqrt(lam + 1) - 1)  
+        D = np.diag(1 / np.sqrt(lam + 1) - 1)  
 
     x, z, zm = [Function(space) for i in range(3)]
     if (ssize>1):
-     zstd = Function(space)
+        zstd = Function(space)
     if (sample_posterior):
-     a, y, am = [Function(space) for i in range(3)]
-     if (ssize>1):
-      astd = Function(space)
+        a, am = [Function(space) for i in range(2)]
+        if (ssize>1):
+            astd = Function(space)
 
     shp = np.shape(z.vector().get_local())
 
-    zm.vector().set_local(np.zeros(shp))
+    zm.vector().zero()
     zm.vector().apply("insert")
     if (ssize>1):
-     zstd.vector().set_local(np.zeros(shp))
-     zstd.vector().apply("insert")
+        zstd.vector().zero()
+        zstd.vector().apply("insert")
     
     if (sample_posterior):
-     am.vector().set_local(np.zeros(shp))
-     am.vector().apply("insert")
-     if (ssize>1):
-      astd.vector().set_local(np.zeros(shp))
-      astd.vector().apply("insert")
+        am.vector().zero()
+        am.vector().apply("insert")
+        y.vector().zero()
+        y.vector().apply("insert")
+        if (ssize>1):
+            astd.vector().zero()
+            astd.vector().apply("insert")
 
+    np.random.seed()
     for i in range(params.sample.sample_size):
 
-      np.random.seed()
-      x.vector().set_local(random.normal(np.zeros(shp),  # N
+        x.vector().set_local(random.normal(np.zeros(shp),  # N
                          np.ones(shp),shp))
-      x.vector().apply("insert")
+        x.vector().apply("insert")
 	  
-      reg_op.sqrt_inv_action(x.vector(),z.vector())  # Gamma 1/2 N
+        reg_op.sqrt_inv_action(x.vector(),z.vector())  # Gamma 1/2 N
 
-      zm.vector().set_local(zm.vector().get_local() + z.vector().get_local()/float(ssize))
-      zm.vector().apply("insert")
-      if (ssize>1):
-       zstd.vector().set_local(zstd.vector().get_local() + z.vector().get_local()**2/float(ssize))
-       zstd.vector().apply("insert")
+        zm.vector().set_local(zm.vector().get_local() + z.vector().get_local()/float(ssize))
+        zm.vector().apply("insert")
+        if (ssize>1):
+            zstd.vector().set_local(zstd.vector().get_local() + z.vector().get_local()**2/float(ssize))
+            zstd.vector().apply("insert")
 
-      if (sample_posterior):
-       reg_op.sqrt_action(x.vector(),y.vector())  # Gamma -1/2 N
+        if (sample_posterior):
+            reg_op.sqrt_action(x.vector(),y.vector())  # Gamma -1/2 N
 
-       tmp1 = np.asarray([w.vector().inner(y.vector()) for w in W])
-       tmp2 = np.dot(D,tmp1)
+            tmp1 = np.asarray([w.vector().inner(y.vector()) for w in W])
+            tmp2 = np.dot(D,tmp1)
 
-       P1 = Function(space)
-       for ind in range(len(tmp2)):
-         P1.vector().axpy(tmp2[ind],W[ind].vector())
+            P1 = Function(space)
+            for ind in range(len(tmp2)):
+                P1.vector().axpy(tmp2[ind],W[ind].vector())
 
-       a.vector().set_local(z.vector().get_local() + P1.vector())
-       a.vector().apply("insert")
+            a.vector().set_local(z.vector().get_local() + P1.vector())
+            a.vector().apply("insert")
 
-       am.vector().set_local(am.vector().get_local() + a.vector().get_local()/float(ssize))
-       am.vector().apply("insert")
-       if (ssize>1):
-        astd.vector().set_local(astd.vector().get_local() + a.vector().get_local()**2/float(ssize))
-        astd.vector().apply("insert")
+            am.vector().set_local(am.vector().get_local() + a.vector().get_local()/float(ssize))
+            am.vector().apply("insert")
+            if (ssize>1):
+                astd.vector().set_local(astd.vector().get_local() + a.vector().get_local()**2/float(ssize))
+                astd.vector().apply("insert")
 
     if (ssize>1):
-     zstd.vector().set_local(np.sqrt(zstd.vector().get_local() - zm.vector().get_local()**2))   
-     zstd.vector().apply("insert")
+        zstd.vector().set_local(np.sqrt(zstd.vector().get_local() - zm.vector().get_local()**2))   
+        zstd.vector().apply("insert")
      
     if (sample_posterior):
-     if (ssize>1):
-      astd.vector().set_local(np.sqrt(astd.vector().get_local() - am.vector().get_local()**2))
-      astd.vector().apply("insert")
+        if (ssize>1):
+            astd.vector().set_local(np.sqrt(astd.vector().get_local() - am.vector().get_local()**2))
+            astd.vector().apply("insert")
 
     if params.inversion.dual:
-      alpha_prior_sample_mean = project(zm[0], slvr.Qp)
-      beta_prior_sample_mean = project(zm[1], slvr.Qp)
-      if (ssize>1):
-       alpha_prior_sample_std = project(zstd[0], slvr.Qp)
-       beta_prior_sample_std = project(zstd[1], slvr.Qp)
+        alpha_prior_sample_mean = project(zm[0], slvr.Qp)
+        beta_prior_sample_mean = project(zm[1], slvr.Qp)
+        if (ssize>1):
+            alpha_prior_sample_std = project(zstd[0], slvr.Qp)
+            beta_prior_sample_std = project(zstd[1], slvr.Qp)
     
-      if (sample_posterior):
-       alpha_post_sample_mean = project(am[0], slvr.Qp)
-       beta_post_sample_mean = project(am[1], slvr.Qp)
-       if (ssize>1):
-        alpha_post_sample_std = project(astd[0], slvr.Qp)
-        beta_post_sample_std = project(astd[1], slvr.Qp)
+        if (sample_posterior):
+            alpha_post_sample_mean = project(am[0], slvr.Qp)
+            beta_post_sample_mean = project(am[1], slvr.Qp)
+            if (ssize>1):
+                alpha_post_sample_std = project(astd[0], slvr.Qp)
+                beta_post_sample_std = project(astd[1], slvr.Qp)
 
     elif alpha_active:
-      alpha_prior_sample_mean = zm
-      if (ssize>1):
-       alpha_prior_sample_std = zstd
+        alpha_prior_sample_mean = zm
+        if (ssize>1):
+            alpha_prior_sample_std = zstd
 
-      if (sample_posterior):
-       alpha_post_sample_mean = am
-       if (ssize>1):
-        alpha_post_sample_std = astd
+        if (sample_posterior):
+            alpha_post_sample_mean = am
+            if (ssize>1):
+                alpha_post_sample_std = astd
 
     elif beta_active:
-      beta_prior_sample_mean = zm
-      if (ssize>1):
-       beta_prior_sample_std = zstd
+        beta_prior_sample_mean = zm
+        if (ssize>1):
+            beta_prior_sample_std = zstd
 
-      if (sample_posterior):
-       beta_post_sample_mean = am
-       if (ssize>1):
-        beta_post_sample_std = astd
+        if (sample_posterior):
+            beta_post_sample_mean = am
+            if (ssize>1):
+                beta_post_sample_std = astd
 
     if ((alpha_active or params.inversion.dual) and params.sample.sample_alpha):
-      inout.write_variable(alpha_prior_sample_mean, params, name="alpha_prior_sample_mean_"+str(ssize), 
-                           outdir=diag_dir,
-                           phase_name=phase_name_sample, 
-                           phase_suffix=phase_suffix_sample)
-      if (ssize>1):
-       inout.write_variable(alpha_prior_sample_std, params, name="alpha_prior_sample_stdev_"+str(ssize), 
-                           outdir=diag_dir,
-                           phase_name=phase_name_sample, 
-                           phase_suffix=phase_suffix_sample)
-      if (sample_posterior):
-       inout.write_variable(alpha_post_sample_mean, params, name="alpha_posterior_sample_mean_"+str(ssize), 
-                           outdir=diag_dir,
-                           phase_name=phase_name_sample, 
-                           phase_suffix=phase_suffix_sample)
-       if (ssize>1):
-        inout.write_variable(alpha_post_sample_std, params, name="alpha_posterior_sample_stdev_"+str(ssize), 
-                           outdir=diag_dir,
-                           phase_name=phase_name_sample, 
-                           phase_suffix=phase_suffix_sample)
+        inout.write_variable(alpha_prior_sample_mean, params, name="alpha_prior_sample_mean_"+str(ssize), 
+                          outdir=diag_dir,
+                          phase_name=phase_name_sample, 
+                          phase_suffix=phase_suffix_sample)
+        if (ssize>1):
+            inout.write_variable(alpha_prior_sample_std, params, name="alpha_prior_sample_stdev_"+str(ssize), 
+                          outdir=diag_dir,
+                          phase_name=phase_name_sample, 
+                          phase_suffix=phase_suffix_sample)
+        if (sample_posterior):
+            inout.write_variable(alpha_post_sample_mean, params, name="alpha_posterior_sample_mean_"+str(ssize), 
+                          outdir=diag_dir,
+                          phase_name=phase_name_sample, 
+                          phase_suffix=phase_suffix_sample)
+        if (ssize>1):
+            inout.write_variable(alpha_post_sample_std, params, name="alpha_posterior_sample_stdev_"+str(ssize), 
+                          outdir=diag_dir,
+                          phase_name=phase_name_sample, 
+                          phase_suffix=phase_suffix_sample)
 
     if ((beta_active or params.inversion.dual) and params.sample.sample_alpha):
-      inout.write_variable(beta_prior_sample_mean, params, name="beta_prior_sample_mean_"+str(ssize), 
-                           outdir=diag_dir,
-                           phase_name=phase_name_sample, 
-                           phase_suffix=phase_suffix_sample)
-      if (ssize>1):
-       inout.write_variable(beta_prior_sample_std, params, name="beta_prior_sample_stdev_"+str(ssize), 
-                           outdir=diag_dir,
-                           phase_name=phase_name_sample, 
-                           phase_suffix=phase_suffix_sample)
-      if (sample_posterior):
-       inout.write_variable(beta_post_sample_mean, params, name="beta_posterior_sample_mean_"+str(ssize), 
-                           outdir=diag_dir,
-                           phase_name=phase_name_sample, 
-                           phase_suffix=phase_suffix_sample)
-       if (ssize>1):
-        inout.write_variable(beta_post_sample_std, params, name="beta_posterior_sample_stdev_"+str(ssize), 
-                           outdir=diag_dir,
-                           phase_name=phase_name_sample, 
-                           phase_suffix=phase_suffix_sample)
+        inout.write_variable(beta_prior_sample_mean, params, name="beta_prior_sample_mean_"+str(ssize), 
+                          outdir=diag_dir,
+                          phase_name=phase_name_sample, 
+                          phase_suffix=phase_suffix_sample)
+        if (ssize>1):
+            inout.write_variable(beta_prior_sample_std, params, name="beta_prior_sample_stdev_"+str(ssize), 
+                          outdir=diag_dir,
+                          phase_name=phase_name_sample, 
+                          phase_suffix=phase_suffix_sample)
+        if (sample_posterior):
+            inout.write_variable(beta_post_sample_mean, params, name="beta_posterior_sample_mean_"+str(ssize), 
+                          outdir=diag_dir,
+                          phase_name=phase_name_sample, 
+                          phase_suffix=phase_suffix_sample)
+        if (ssize>1):
+            inout.write_variable(beta_post_sample_std, params, name="beta_posterior_sample_stdev_"+str(ssize), 
+                          outdir=diag_dir,
+                          phase_name=phase_name_sample, 
+                          phase_suffix=phase_suffix_sample)
 
 if __name__ == "__main__":
     assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"

--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -43,6 +43,7 @@ def run_sample(config_file):
     inout.log_preamble("errorprop", params)
 
     ssize = params.sample.sample_size
+    sample_posterior = params.sample.sample_posterior
     alpha_active = params.inversion.alpha_active
     beta_active = params.inversion.beta_active
     log = inout.setup_logging(params)
@@ -96,58 +97,78 @@ def run_sample(config_file):
     Prior = mdl.get_prior()
     reg_op = Prior(slvr, space)
 
-    x, y, z = [Function(space) for i in range(3)]
+#    x, y, z = [Function(space) for i in range(3)]
+    y = Function(space)
 
-    # Loads eigenvalues from file
-    outdir_e = Path(outdir)/phase_name_e/phase_suffix_e
-    with open(outdir_e/lamfile, 'rb') as ff:
-        eigendata = pickle.load(ff)
-        lam = eigendata[0].real.astype(np.float64)
-        nlam = len(lam)
+    if (sample_posterior):
 
-
-    # Check if eigendecomposition successfully produced num_eig
-    # or if some are NaN
-    if np.any(np.isnan(lam)):
-        nlam = np.argwhere(np.isnan(lam))[0][0]
-        lam = lam[:nlam]
-
-    # and eigenvectors from .h5 file
-    eps = params.constants.float_eps
-    W = []
-    with HDF5File(MPI.comm_world, str(outdir_e/vecfile), 'r') as hdf5data:
-        for i in range(len(lam)):
-            w = Function(space)
-            hdf5data.read(w, f'v/vector_{i}')
-
-            # Test norm in prior == 1.0
-            reg_op.action(w.vector(), y.vector())
-            norm_in_prior = w.vector().inner(y.vector())
-            assert (abs(norm_in_prior - 1.0) < eps)
-
-            W.append(w)
+      # Loads eigenvalues from file
+      outdir_e = Path(outdir)/phase_name_e/phase_suffix_e
+      with open(outdir_e/lamfile, 'rb') as ff:
+          eigendata = pickle.load(ff)
+          lam = eigendata[0].real.astype(np.float64)
+          nlam = len(lam)
 
 
-    # take only the largest eigenvalues
-    pind = np.flatnonzero(lam > threshlam)
-    lam = lam[pind]
-    nlam = len(lam)
-    W = [W[i] for i in pind]
+      # Check if eigendecomposition successfully produced num_eig
+      # or if some are NaN
+      if np.any(np.isnan(lam)):
+          nlam = np.argwhere(np.isnan(lam))[0][0]
+          lam = lam[:nlam]
+
+      # and eigenvectors from .h5 file
+      eps = params.constants.float_eps
+      W = []
+
+      max_lam = params.sample.num_eigenvals
+      if (max_lam > 0):
+          lam = lam[:max_lam] 
+
+      with HDF5File(MPI.comm_world, str(outdir_e/vecfile), 'r') as hdf5data:
+          for i in range(len(lam)):
+              w = Function(space)
+              hdf5data.read(w, f'v/vector_{i}')
+
+              # Test norm in prior == 1.0
+              reg_op.action(w.vector(), y.vector())
+              norm_in_prior = w.vector().inner(y.vector())
+              assert (abs(norm_in_prior - 1.0) < eps)
+
+              W.append(w)
+
+
+      # take only the largest eigenvalues
+      pind = np.flatnonzero(lam > threshlam)
+      lam = lam[pind]
+      nlam = len(lam)
+      W = [W[i] for i in pind]
 
 ### ABOVE THIS POINT CODE IS BORROWED FROM RUN_ERRORPROP.PY
 
-    D = np.diag(1 / np.sqrt(lam + 1) - 1)  
+      D = np.diag(1 / np.sqrt(lam + 1) - 1)  
 
-    x, y, z, a, zm, zstd, am, astd= [Function(space) for i in range(8)]
+    x, z, zm = [Function(space) for i in range(3)]
+    if (ssize>1):
+     zstd = Function(space)
+    if (sample_posterior):
+     a, y, am = [Function(space) for i in range(3)]
+     if (ssize>1):
+      astd = Function(space)
+
     shp = np.shape(z.vector().get_local())
+
     zm.vector().set_local(np.zeros(shp))
     zm.vector().apply("insert")
-    zstd.vector().set_local(np.zeros(shp))
-    zstd.vector().apply("insert")
-    am.vector().set_local(np.zeros(shp))
-    am.vector().apply("insert")
-    astd.vector().set_local(np.zeros(shp))
-    astd.vector().apply("insert")
+    if (ssize>1):
+     zstd.vector().set_local(np.zeros(shp))
+     zstd.vector().apply("insert")
+    
+    if (sample_posterior):
+     am.vector().set_local(np.zeros(shp))
+     am.vector().apply("insert")
+     if (ssize>1):
+      astd.vector().set_local(np.zeros(shp))
+      astd.vector().apply("insert")
 
     for i in range(params.sample.sample_size):
 
@@ -156,66 +177,87 @@ def run_sample(config_file):
                          np.ones(shp),shp))
       x.vector().apply("insert")
 	  
-      reg_op.sqrt_action(x.vector(),y.vector())  # Gamma -1/2 N
       reg_op.sqrt_inv_action(x.vector(),z.vector())  # Gamma 1/2 N
 
-      tmp1 = np.asarray([w.vector().inner(y.vector()) for w in W])
-      tmp2 = np.dot(D,tmp1)
-
-      P1 = Function(space)
-      for ind in range(len(tmp2)):
-        P1.vector().axpy(tmp2[ind],W[ind].vector())
-
-      a.vector().set_local(z.vector().get_local() + P1.vector())
-      a.vector().apply("insert")
-
       zm.vector().set_local(zm.vector().get_local() + z.vector().get_local()/float(ssize))
-      am.vector().set_local(am.vector().get_local() + a.vector().get_local()/float(ssize))
-      zstd.vector().set_local(zstd.vector().get_local() + z.vector().get_local()**2/float(ssize))
-      astd.vector().set_local(astd.vector().get_local() + a.vector().get_local()**2/float(ssize))
+      if (ssize>1):
+       zstd.vector().set_local(zstd.vector().get_local() + z.vector().get_local()**2/float(ssize))
 
-    zstd.vector().set_local(zstd.vector().get_local() - zm.vector().get_local()**2)   
-    astd.vector().set_local(astd.vector().get_local() - am.vector().get_local()**2)
+      if (sample_posterior):
+       reg_op.sqrt_action(x.vector(),y.vector())  # Gamma -1/2 N
+
+       tmp1 = np.asarray([w.vector().inner(y.vector()) for w in W])
+       tmp2 = np.dot(D,tmp1)
+
+       P1 = Function(space)
+       for ind in range(len(tmp2)):
+         P1.vector().axpy(tmp2[ind],W[ind].vector())
+
+       a.vector().set_local(z.vector().get_local() + P1.vector())
+       a.vector().apply("insert")
+
+       am.vector().set_local(am.vector().get_local() + a.vector().get_local()/float(ssize))
+       if (ssize>1):
+        astd.vector().set_local(astd.vector().get_local() + a.vector().get_local()**2/float(ssize))
+
+    if (ssize>1):
+     zstd.vector().set_local(np.sqrt(zstd.vector().get_local() - zm.vector().get_local()**2))   
+     
+    if (sample_posterior):
+     if (ssize>1):
+      astd.vector().set_local(np.sqrt(astd.vector().get_local() - am.vector().get_local()**2))
 
     if params.inversion.dual:
       alpha_prior_sample_mean = project(zm[0], slvr.Qp)
       beta_prior_sample_mean = project(zm[1], slvr.Qp)
-      alpha_prior_sample_std = project(zstd[0], slvr.Qp)
-      beta_prior_sample_std = project(zstd[1], slvr.Qp)
-
-      alpha_post_sample_mean = project(am[0], slvr.Qp)
-      beta_post_sample_mean = project(am[1], slvr.Qp)
-      alpha_post_sample_std = project(astd[0], slvr.Qp)
-      beta_post_sample_std = project(astd[1], slvr.Qp)
+      if (ssize>1):
+       alpha_prior_sample_std = project(zstd[0], slvr.Qp)
+       beta_prior_sample_std = project(zstd[1], slvr.Qp)
+    
+      if (sample_posterior):
+       alpha_post_sample_mean = project(am[0], slvr.Qp)
+       beta_post_sample_mean = project(am[1], slvr.Qp)
+       if (ssize>1):
+        alpha_post_sample_std = project(astd[0], slvr.Qp)
+        beta_post_sample_std = project(astd[1], slvr.Qp)
 
     elif alpha_active:
       alpha_prior_sample_mean = zm
-      alpha_prior_sample_std = zstd
+      if (ssize>1):
+       alpha_prior_sample_std = zstd
 
-      alpha_post_sample_mean = am
-      alpha_post_sample_std = astd
+      if (sample_posterior):
+       alpha_post_sample_mean = am
+       if (ssize>1):
+        alpha_post_sample_std = astd
 
     elif beta_active:
       beta_prior_sample_mean = zm
-      beta_prior_sample_std = zstd
+      if (ssize>1):
+       beta_prior_sample_std = zstd
 
-      beta_post_sample_mean = am
-      beta_post_sample_std = astd
+      if (sample_posterior):
+       beta_post_sample_mean = am
+       if (ssize>1):
+        beta_post_sample_std = astd
 
     if ((alpha_active or params.inversion.dual) and params.sample.sample_alpha):
       inout.write_variable(alpha_prior_sample_mean, params, name="alpha_prior_sample_mean_"+str(ssize), 
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 
                            phase_suffix=phase_suffix_sample)
-      inout.write_variable(alpha_prior_sample_std, params, name="alpha_prior_sample_stdev_"+str(ssize), 
+      if (ssize>1):
+       inout.write_variable(alpha_prior_sample_std, params, name="alpha_prior_sample_stdev_"+str(ssize), 
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 
                            phase_suffix=phase_suffix_sample)
-      inout.write_variable(alpha_post_sample_mean, params, name="alpha_posterior_sample_mean_"+str(ssize), 
+      if (sample_posterior):
+       inout.write_variable(alpha_post_sample_mean, params, name="alpha_posterior_sample_mean_"+str(ssize), 
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 
                            phase_suffix=phase_suffix_sample)
-      inout.write_variable(alpha_post_sample_std, params, name="alpha_posterior_sample_stdev_"+str(ssize), 
+       if (ssize>1):
+        inout.write_variable(alpha_post_sample_std, params, name="alpha_posterior_sample_stdev_"+str(ssize), 
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 
                            phase_suffix=phase_suffix_sample)
@@ -225,15 +267,18 @@ def run_sample(config_file):
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 
                            phase_suffix=phase_suffix_sample)
-      inout.write_variable(beta_prior_sample_std, params, name="beta_prior_sample_stdev_"+str(ssize), 
+      if (ssize>1):
+       inout.write_variable(beta_prior_sample_std, params, name="beta_prior_sample_stdev_"+str(ssize), 
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 
                            phase_suffix=phase_suffix_sample)
-      inout.write_variable(beta_post_sample_mean, params, name="beta_posterior_sample_mean_"+str(ssize), 
+      if (sample_posterior):
+       inout.write_variable(beta_post_sample_mean, params, name="beta_posterior_sample_mean_"+str(ssize), 
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 
                            phase_suffix=phase_suffix_sample)
-      inout.write_variable(beta_post_sample_std, params, name="beta_posterior_sample_stdev_"+str(ssize), 
+       if (ssize>1):
+        inout.write_variable(beta_post_sample_std, params, name="beta_posterior_sample_stdev_"+str(ssize), 
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 
                            phase_suffix=phase_suffix_sample)

--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -137,15 +137,12 @@ def run_sample(config_file):
     nlam = len(lam)
     W = [W[i] for i in pind]
 
-    D = np.diag(lam / (lam + 1))  # D_r Isaac 20
-
 ### ABOVE THIS POINT CODE IS BORROWED FROM RUN_ERRORPROP.PY
 
-    
+    D = np.diag(1 / np.sqrt(lam + 1) - 1)  
 
     x, y, z, a, zm, zstd, am, astd= [Function(space) for i in range(8)]
     shp = np.shape(z.vector().get_local())
-
     zm.vector().set_local(np.zeros(shp))
     zm.vector().apply("insert")
     zstd.vector().set_local(np.zeros(shp))
@@ -161,11 +158,11 @@ def run_sample(config_file):
       x.vector().set_local(random.normal(np.zeros(shp),  # N
                          np.ones(shp),shp))
       x.vector().apply("insert")
- 
+	  
       reg_op.sqrt_action(x.vector(),y.vector())  # Gamma -1/2 N
       reg_op.sqrt_inv_action(x.vector(),z.vector())  # Gamma 1/2 N
 
-      tmp1 = np.dot(W.T,y.vector().get_local())
+      tmp1 = np.asarray([w.vector().inner(y.vector()) for w in W])
       tmp2 = np.dot(D,tmp1)
       P1 = np.dot(W,tmp2)
 

--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -1,0 +1,240 @@
+cs_ice copyright information see ACKNOWLEDGEMENTS in the fenics_ice
+# root directory
+
+# This file is part of fenics_ice.
+#
+# fenics_ice is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# fenics_ice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
+
+from fenics_ice.backend import Function, HDF5File, MPI
+
+import os
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+
+import sys
+import numpy as np
+import pickle
+from pathlib import Path
+
+from fenics_ice import model, solver, prior, inout
+from fenics_ice import mesh as fice_mesh
+from fenics_ice.config import ConfigParser
+from IPython import embed
+
+import matplotlib as mpl
+mpl.use("Agg")
+import matplotlib.pyplot as plt
+
+def run_sample(config_file):
+
+    # Read run config file
+    params = ConfigParser(config_file)
+    log = inout.setup_logging(params)
+    inout.log_preamble("errorprop", params)
+
+    ssize = params.sample.sample_size
+    alpha_active = params.inversion.alpha_active
+    beta_active = params.inversion.beta_active
+    log = inout.setup_logging(params)
+    inout.log_preamble("errorprop", params)
+
+    phase_name_sample = params.sample.[hase_name
+    phase_suffix_sample = params.sample.phase_suffix
+
+    outdir = params.io.output_dir
+
+    # Load the static model data (geometry, smb, etc)
+    input_data = inout.InputData(params)
+
+    #Eigen value params
+    phase_name = params.eigendec.phase_name
+    phase_suffix = params.eigendec.phase_suffix
+    lamfile = params.io.eigenvalue_file
+    vecfile = params.io.eigenvecs_file
+    threshlam = params.eigendec.eigenvalue_thresh
+
+    # Qoi forward params
+    phase_time = params.time.phase_name
+    phase_suffix_qoi = params.time.phase_suffix
+    dqoi_h5file = params.io.dqoi_h5file
+
+    if len(phase_suffix_e) > 0:
+        lamfile = params.io.run_name + phase_suffix_e + '_eigvals.p'
+        vecfile = params.io.run_name + phase_suffix_e + '_vr.h5'
+    if len(phase_suffix_qoi) > 0:
+        dqoi_h5file = params.io.run_name + phase_suffix_qoi + '_dQ_ts.h5'
+
+    # Get model mesh
+    mesh = fice_mesh.get_mesh(params)
+
+    # Define the model
+    mdl = model.model(mesh, input_data, params)
+
+    # Load alpha/beta fields
+    mdl.alpha_from_inversion()
+    mdl.beta_from_inversion()
+    mdl.bglen_from_data(mask_only=True)
+
+    # Setup our solver object
+    slvr = solver.ssa_solver(mdl, mixed_space=params.inversion.dual)
+
+    cntrl = slvr.get_control()[0]
+    space = slvr.get_control_space()
+
+    # Regularization operator using inversion delta/gamma values
+    Prior = mdl.get_prior()
+    reg_op = Prior(slvr, space)
+
+    x, y, z = [Function(space) for i in range(3)]
+
+    # Loads eigenvalues from file
+    outdir_e = Path(outdir)/phase_eigen/phase_suffix_e
+    with open(outdir_e/lamfile, 'rb') as ff:
+        eigendata = pickle.load(ff)
+        lam = eigendata[0].real.astype(np.float64)
+        nlam = len(lam)
+
+    # Check if eigendecomposition successfully produced num_eig
+    # or if some are NaN
+    if np.any(np.isnan(lam)):
+        nlam = np.argwhere(np.isnan(lam))[0][0]
+        lam = lam[:nlam]
+
+    # and eigenvectors from .h5 file
+    eps = params.constants.float_eps
+    W = []
+    with HDF5File(MPI.comm_world, str(outdir_e/vecfile), 'r') as hdf5data:
+        for i in range(nlam):
+            w = Function(space)
+            hdf5data.read(w, f'v/vector_{i}')
+
+            # Test norm in prior == 1.0
+            reg_op.action(w.vector(), y.vector())
+            norm_in_prior = w.vector().inner(y.vector())
+            assert (abs(norm_in_prior - 1.0) < eps)
+
+            W.append(w)
+
+    # take only the largest eigenvalues
+    pind = np.flatnonzero(lam > threshlam)
+    lam = lam[pind]
+    nlam = len(lam)
+    W = [W[i] for i in pind]
+
+    D = np.diag(lam / (lam + 1))  # D_r Isaac 20
+
+### ABOVE THIS POINT CODE IS BORROWED FROM RUN_ERRORPROP.PY
+
+    
+
+    x, y, z, a zm, zstd, am, astd= [Function(space) for i in range(8)]
+    shp = np.shape(z.vector().get_local())
+
+    zm.vector().set_local(np.zeros(shp))
+    zm.vector().apply("insert")
+    zstd.vector().set_local(np.zeros(shp))
+    zstd.vector().apply("insert")
+    am.vector().set_local(np.zeros(shp))
+    am.vector().apply("insert")
+    astd.vector().set_local(np.zeros(shp))
+    astd.vector().apply("insert")
+
+    for i in range(params.sample.sample_size):
+
+      np.random.seed()
+      x.vector().set_local(random.normal(np.zeros(shp),  # N
+                         np.ones(shp),shp))
+      x.vector().apply("insert")
+ 
+      reg_op.sqrt_action(x.vector(),y.vector())  # Gamma -1/2 N
+      reg_op.sqrt_inv_action(x.vector(),z.vector())  # Gamma 1/2 N
+
+      tmp1 = np.dot(W.T,y.vector().get_local())
+      tmp2 = np.dot(D,tmp1)
+      P1 = np.dot(W,tmp2)
+
+      a.vector().set_local(z.vector().get_local() + P1)
+      a.vector().apply("insert")
+
+      zm.vector().set_local(zm.vector().get_local() + z.vector().get_local()/ssize)
+      am.vector().set_local(am.vector().get_local() + a.vector().get_local()/ssize)
+      zstd.vector().set_local(zstd.vector().get_local() + z.vector().get_local()**2/ssize)
+      astd.vector().set_local(astd.vector().get_local() + a.vector().get_local()**2/ssize)
+
+   zstd.vector().set_local(zstd.vector().get_local() - zm.vector().get_local()**2)   
+   astd.vector().set_local(astd.vector().get_local() - am.vector().get_local()**2)
+
+   if params.inversion.dual:
+      alpha_prior_sample_mean = project(zm[0], self.Qp)
+      beta_prior_sample_mean = project(zm[1], self.Qp)
+      alpha_prior_sample_std = project(zstd[0], self.Qp)
+      beta_prior_sample_std = project(zstd[1], self.Qp)
+
+      alpha_post_sample_mean = project(am[0], self.Qp)
+      beta_post_sample_mean = project(am[1], self.Qp)
+      alpha_post_sample_std = project(astd[0], self.Qp)
+      beta_post_sample_std = project(astd[1], self.Qp)
+
+   else if alpha_active:
+      alpha_prior_sample_mean = zm
+      alpha_prior_sample_std = zstd
+
+      alpha_post_sample_mean = am
+      alpha_post_sample_std = astd
+
+   else if beta_active:
+      beta_prior_sample_mean = zm
+      beta_prior_sample_std = zstd
+
+      beta_post_sample_mean = am
+      beta_post_sample_std = astd
+
+   if (alpha_active or params.inversion.dual):
+      inout.write_variable(alpha_prior_sample_mean, params, name="alpha_prior_sample_mean_"+str(ssize), 
+                           outdir=diag_dir,
+                           phase_name=phase_name_sample, 
+                           phase_suffix=phase_suffix_sample)
+      inout.write_variable(alpha_prior_sample_std, params, name="alpha_prior_sample_stdev_"+str(ssize), 
+                           outdir=diag_dir,
+                           phase_name=phase_name_sample, 
+                           phase_suffix=phase_suffix_sample)
+      inout.write_variable(alpha_post_sample_mean, params, name="alpha_posterior_sample_mean_"+str(ssize), 
+                           outdir=diag_dir,
+                           phase_name=phase_name_sample, 
+                           phase_suffix=phase_suffix_sample)
+      inout.write_variable(alpha_post_sample_std, params, name="alpha_posterior_sample_stdev_"+str(ssize), 
+                           outdir=diag_dir,
+                           phase_name=phase_name_sample, 
+                           phase_suffix=phase_suffix_sample)
+
+   if (beta_active or params.inversion.dual):
+      inout.write_variable(beta_prior_sample_mean, params, name="beta_prior_sample_mean_"+str(ssize), 
+                           outdir=diag_dir,
+                           phase_name=phase_name_sample, 
+                           phase_suffix=phase_suffix_sample)
+      inout.write_variable(beta_prior_sample_std, params, name="beta_prior_sample_stdev_"+str(ssize), 
+                           outdir=diag_dir,
+                           phase_name=phase_name_sample, 
+                           phase_suffix=phase_suffix_sample)
+      inout.write_variable(beta_post_sample_mean, params, name="beta_posterior_sample_mean_"+str(ssize), 
+                           outdir=diag_dir,
+                           phase_name=phase_name_sample, 
+                           phase_suffix=phase_suffix_sample)
+      inout.write_variable(beta_post_sample_std, params, name="beta_posterior_sample_stdev_"+str(ssize), 
+                           outdir=diag_dir,
+                           phase_name=phase_name_sample, 
+                           phase_suffix=phase_suffix_sample)
+
+if __name__ == "__main__":
+    assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"
+    run_sample(sys.argv[1])

--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -260,8 +260,8 @@ def run_sample(config_file):
                           outdir=diag_dir,
                           phase_name=phase_name_sample, 
                           phase_suffix=phase_suffix_sample)
-        if (ssize>1):
-            inout.write_variable(alpha_post_sample_std, params, name="alpha_posterior_sample_stdev_"+str(ssize), 
+            if (ssize>1):
+                inout.write_variable(alpha_post_sample_std, params, name="alpha_posterior_sample_stdev_"+str(ssize), 
                           outdir=diag_dir,
                           phase_name=phase_name_sample, 
                           phase_suffix=phase_suffix_sample)
@@ -281,8 +281,8 @@ def run_sample(config_file):
                           outdir=diag_dir,
                           phase_name=phase_name_sample, 
                           phase_suffix=phase_suffix_sample)
-        if (ssize>1):
-            inout.write_variable(beta_post_sample_std, params, name="beta_posterior_sample_stdev_"+str(ssize), 
+            if (ssize>1):
+                inout.write_variable(beta_post_sample_std, params, name="beta_posterior_sample_stdev_"+str(ssize), 
                           outdir=diag_dir,
                           phase_name=phase_name_sample, 
                           phase_suffix=phase_suffix_sample)

--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -166,10 +166,10 @@ def run_sample(config_file):
       a.vector().set_local(z.vector().get_local() + P1)
       a.vector().apply("insert")
 
-      zm.vector().set_local(zm.vector().get_local() + z.vector().get_local()/ssize)
-      am.vector().set_local(am.vector().get_local() + a.vector().get_local()/ssize)
-      zstd.vector().set_local(zstd.vector().get_local() + z.vector().get_local()**2/ssize)
-      astd.vector().set_local(astd.vector().get_local() + a.vector().get_local()**2/ssize)
+      zm.vector().set_local(zm.vector().get_local() + z.vector().get_local()/float(ssize))
+      am.vector().set_local(am.vector().get_local() + a.vector().get_local()/float(ssize))
+      zstd.vector().set_local(zstd.vector().get_local() + z.vector().get_local()**2/float(ssize))
+      astd.vector().set_local(astd.vector().get_local() + a.vector().get_local()**2/float(ssize))
 
    zstd.vector().set_local(zstd.vector().get_local() - zm.vector().get_local()**2)   
    astd.vector().set_local(astd.vector().get_local() - am.vector().get_local()**2)
@@ -199,7 +199,7 @@ def run_sample(config_file):
       beta_post_sample_mean = am
       beta_post_sample_std = astd
 
-   if (alpha_active or params.inversion.dual):
+   if ((alpha_active or params.inversion.dual) and params.sample.sample_alpha):
       inout.write_variable(alpha_prior_sample_mean, params, name="alpha_prior_sample_mean_"+str(ssize), 
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 
@@ -217,7 +217,7 @@ def run_sample(config_file):
                            phase_name=phase_name_sample, 
                            phase_suffix=phase_suffix_sample)
 
-   if (beta_active or params.inversion.dual):
+   if ((beta_active or params.inversion.dual) and params.sample.sample_alpha):
       inout.write_variable(beta_prior_sample_mean, params, name="beta_prior_sample_mean_"+str(ssize), 
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 

--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -1,4 +1,4 @@
-cs_ice copyright information see ACKNOWLEDGEMENTS in the fenics_ice
+# For fenics_ice copyright information see ACKNOWLEDGEMENTS in the fenics_ice
 # root directory
 
 # This file is part of fenics_ice.
@@ -48,7 +48,7 @@ def run_sample(config_file):
     log = inout.setup_logging(params)
     inout.log_preamble("errorprop", params)
 
-    phase_name_sample = params.sample.[hase_name
+    phase_name_sample = params.sample.phase_name
     phase_suffix_sample = params.sample.phase_suffix
 
     outdir = params.io.output_dir
@@ -137,7 +137,7 @@ def run_sample(config_file):
 
     
 
-    x, y, z, a zm, zstd, am, astd= [Function(space) for i in range(8)]
+    x, y, z, a, zm, zstd, am, astd= [Function(space) for i in range(8)]
     shp = np.shape(z.vector().get_local())
 
     zm.vector().set_local(np.zeros(shp))
@@ -171,10 +171,10 @@ def run_sample(config_file):
       zstd.vector().set_local(zstd.vector().get_local() + z.vector().get_local()**2/float(ssize))
       astd.vector().set_local(astd.vector().get_local() + a.vector().get_local()**2/float(ssize))
 
-   zstd.vector().set_local(zstd.vector().get_local() - zm.vector().get_local()**2)   
-   astd.vector().set_local(astd.vector().get_local() - am.vector().get_local()**2)
+    zstd.vector().set_local(zstd.vector().get_local() - zm.vector().get_local()**2)   
+    astd.vector().set_local(astd.vector().get_local() - am.vector().get_local()**2)
 
-   if params.inversion.dual:
+    if params.inversion.dual:
       alpha_prior_sample_mean = project(zm[0], self.Qp)
       beta_prior_sample_mean = project(zm[1], self.Qp)
       alpha_prior_sample_std = project(zstd[0], self.Qp)
@@ -185,21 +185,21 @@ def run_sample(config_file):
       alpha_post_sample_std = project(astd[0], self.Qp)
       beta_post_sample_std = project(astd[1], self.Qp)
 
-   else if alpha_active:
+    elif alpha_active:
       alpha_prior_sample_mean = zm
       alpha_prior_sample_std = zstd
 
       alpha_post_sample_mean = am
       alpha_post_sample_std = astd
 
-   else if beta_active:
+    elif beta_active:
       beta_prior_sample_mean = zm
       beta_prior_sample_std = zstd
 
       beta_post_sample_mean = am
       beta_post_sample_std = astd
 
-   if ((alpha_active or params.inversion.dual) and params.sample.sample_alpha):
+    if ((alpha_active or params.inversion.dual) and params.sample.sample_alpha):
       inout.write_variable(alpha_prior_sample_mean, params, name="alpha_prior_sample_mean_"+str(ssize), 
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 
@@ -217,7 +217,7 @@ def run_sample(config_file):
                            phase_name=phase_name_sample, 
                            phase_suffix=phase_suffix_sample)
 
-   if ((beta_active or params.inversion.dual) and params.sample.sample_alpha):
+    if ((beta_active or params.inversion.dual) and params.sample.sample_alpha):
       inout.write_variable(beta_prior_sample_mean, params, name="beta_prior_sample_mean_"+str(ssize), 
                            outdir=diag_dir,
                            phase_name=phase_name_sample, 

--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -180,8 +180,10 @@ def run_sample(config_file):
       reg_op.sqrt_inv_action(x.vector(),z.vector())  # Gamma 1/2 N
 
       zm.vector().set_local(zm.vector().get_local() + z.vector().get_local()/float(ssize))
+      zm.vector().apply("insert")
       if (ssize>1):
        zstd.vector().set_local(zstd.vector().get_local() + z.vector().get_local()**2/float(ssize))
+       zstd.vector().apply("insert")
 
       if (sample_posterior):
        reg_op.sqrt_action(x.vector(),y.vector())  # Gamma -1/2 N
@@ -197,15 +199,19 @@ def run_sample(config_file):
        a.vector().apply("insert")
 
        am.vector().set_local(am.vector().get_local() + a.vector().get_local()/float(ssize))
+       am.vector().apply("insert")
        if (ssize>1):
         astd.vector().set_local(astd.vector().get_local() + a.vector().get_local()**2/float(ssize))
+        astd.vector().apply("insert")
 
     if (ssize>1):
      zstd.vector().set_local(np.sqrt(zstd.vector().get_local() - zm.vector().get_local()**2))   
+     zstd.vector().apply("insert")
      
     if (sample_posterior):
      if (ssize>1):
       astd.vector().set_local(np.sqrt(astd.vector().get_local() - am.vector().get_local()**2))
+      astd.vector().apply("insert")
 
     if params.inversion.dual:
       alpha_prior_sample_mean = project(zm[0], slvr.Qp)

--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from fenics_ice import model, solver, prior, inout
 from fenics_ice import mesh as fice_mesh
 from fenics_ice.config import ConfigParser
+from numpy import random
 from IPython import embed
 
 import matplotlib as mpl
@@ -104,17 +105,21 @@ def run_sample(config_file):
         lam = eigendata[0].real.astype(np.float64)
         nlam = len(lam)
 
+
     # Check if eigendecomposition successfully produced num_eig
     # or if some are NaN
     if np.any(np.isnan(lam)):
         nlam = np.argwhere(np.isnan(lam))[0][0]
         lam = lam[:nlam]
 
+    lam = lam[:10]
+
     # and eigenvectors from .h5 file
     eps = params.constants.float_eps
     W = []
     with HDF5File(MPI.comm_world, str(outdir_e/vecfile), 'r') as hdf5data:
-        for i in range(nlam):
+        for i in range(len(lam)):
+            print(i)
             w = Function(space)
             hdf5data.read(w, f'v/vector_{i}')
 
@@ -124,6 +129,7 @@ def run_sample(config_file):
             assert (abs(norm_in_prior - 1.0) < eps)
 
             W.append(w)
+
 
     # take only the largest eigenvalues
     pind = np.flatnonzero(lam > threshlam)

--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -57,8 +57,8 @@ def run_sample(config_file):
     input_data = inout.InputData(params)
 
     #Eigen value params
-    phase_name = params.eigendec.phase_name
-    phase_suffix = params.eigendec.phase_suffix
+    phase_name_e = params.eigendec.phase_name
+    phase_suffix_e = params.eigendec.phase_suffix
     lamfile = params.io.eigenvalue_file
     vecfile = params.io.eigenvecs_file
     threshlam = params.eigendec.eigenvalue_thresh
@@ -71,8 +71,8 @@ def run_sample(config_file):
     if len(phase_suffix_e) > 0:
         lamfile = params.io.run_name + phase_suffix_e + '_eigvals.p'
         vecfile = params.io.run_name + phase_suffix_e + '_vr.h5'
-    if len(phase_suffix_qoi) > 0:
-        dqoi_h5file = params.io.run_name + phase_suffix_qoi + '_dQ_ts.h5'
+#    if len(phase_suffix_qoi) > 0:
+#        dqoi_h5file = params.io.run_name + phase_suffix_qoi + '_dQ_ts.h5'
 
     # Get model mesh
     mesh = fice_mesh.get_mesh(params)
@@ -98,7 +98,7 @@ def run_sample(config_file):
     x, y, z = [Function(space) for i in range(3)]
 
     # Loads eigenvalues from file
-    outdir_e = Path(outdir)/phase_eigen/phase_suffix_e
+    outdir_e = Path(outdir)/phase_name_e/phase_suffix_e
     with open(outdir_e/lamfile, 'rb') as ff:
         eigendata = pickle.load(ff)
         lam = eigendata[0].real.astype(np.float64)


### PR DESCRIPTION
**What feature does this add?**

This P/R predominantly adds a the run script  `fenics_ice/runs/run_sample.py`, which enables sampling **zero-mean** realisations from the _prior_ and _posterior_ distributions of `alpha` and `beta`. 

What this means is that e.g. `alpha` is represented by a random vector with gaussian distribution given by mean alpha_0 and covariance Gamma_0, i.e. the prior distribution is N (alpha_0, Gamma_0). This pull request enables a _sample_ of from the distribution, but with **zero mean**, i.e. N( 0, Gamma_0 ). Hence the effects of the covariance matrix can be more clearly seen. (By default, i believe our alpha_0 = 0, but this should be checked. **Note alpha_0 is not the initial guess for alpha!**)

The prior sample is generated by generating an array of independent standard normals of the size of alpha (or beta), and left-mutiplying by the _square root_ of the prior covariance. Thus, if the prior covariance is L M^{-1} L, the square root is L M^{-1/2}.

There is an option to additionally sample the _posterior_ distribution (see Koziol et al, 2021, 5.3.1 for a description of the mathematics involved). Again, this samples form a distribution with the posterior covariance, but zero mean, allowing for a better visualisation of posterior uncertainty. Note that if the posterior is sampled, this assumes a completed eigendecomposition, the location of which is indicated by the toml. The run will fail if none is found.

The run script uses `write_variable` to save the relevant diagnostics files to the appropriate directory.

A new section `sample` has been added to the .toml file, with parameters:

```python
sample_size: int = 1                            # The number of samples to take -- if larger than 1, the mean and standard deviation over the samples is found. not sure this makes sense to do but it was included.
sample_alpha: bool = False                # choose whether to sample alpha or not.
sample_beta: bool = False                 # choose whether to sample beta or not.
sample_posterior: bool = False          # choose whether to sample the posterior or not. 
num_eigenvals: int = 0                       # The maximum number of eigenvalues retained in the posterior sample. If zero or larger than the full number of eigenvalues, the full number is retained (subject to eigenvalue_thresh). 
phase_name: str = 'sample'               # parameter to determine save location for diagnostics
phase_suffix: str = ''                           # parameter to determine suffix for diagnostics
```

In addition, `prior.py` is modified to find the prior square root and inverse sq root action, `sqrt_matrix_action.py` was added to `fenics_ice` to enable the square root of the mass matrix, and `config.py` was modified as above.

_**NOTE: in sqrt_matrix_action.py the maximum iter count was set to 1e5. This is much larger than that needed in the idealised problem in Koziol et al, 2021, GMD.**_

