### PR TITLE
fixed bug where sampling beta could not be turned off

### DIFF
--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -266,7 +266,7 @@ def run_sample(config_file):
                           phase_name=phase_name_sample, 
                           phase_suffix=phase_suffix_sample)
 
-    if ((beta_active or params.inversion.dual) and params.sample.sample_alpha):
+    if ((beta_active or params.inversion.dual) and params.sample.sample_beta):
         inout.write_variable(beta_prior_sample_mean, params, name="beta_prior_sample_mean_"+str(ssize), 
                           outdir=diag_dir,
                           phase_name=phase_name_sample, 


### PR DESCRIPTION
This is a super simple bug fix, so simple it is just one line change and i didn't test it because it won't affect any pytests.

I configured `run_sample` to be able to sample from either beta or alpha or both, but i noticed a bug where the check is against the wrong boolean toml paramter (`sample_alpha`, which is changed to `sample_beta` in this bug fix)

https://github.com/dngoldberg/fenics_ice-1/blob/c80c94a21d7dbd73f388deea1da6f210b8162207/runs/run_sample.py#L269

