### PR TITLE
adding test for smith error prop 

### DIFF
--- a/example_cases/smith_glacier/smith.toml
+++ b/example_cases/smith_glacier/smith.toml
@@ -113,15 +113,15 @@ nonzero_initial_guess = false
 
 [time]
 
-run_length = 40.0
+run_length = 4
 #steps_per_year = 30
-total_steps = 960
-#dt = 0.033333333
-num_sens = 15 #TODO rename
+total_steps = 100
+#dt = 0.0333333I33
+num_sens = 2 #TODO rename
 
 [eigendec]
 
-num_eig = 15000
+num_eig = 10
 eig_algo = "slepc"
 misfit_only = true
 

--- a/example_cases/smith_glacier/smith.toml
+++ b/example_cases/smith_glacier/smith.toml
@@ -144,3 +144,4 @@ patch_downscale = 0.1
 # expected_J_inv = 625620918.9914922 
 #expected_J_inv = 566220228.1028463
 expected_J_inv = 283225902.94674975
+expected_Q_sigma = 5.85873469e+10

--- a/example_cases/smith_glacier/smith.toml
+++ b/example_cases/smith_glacier/smith.toml
@@ -113,15 +113,16 @@ nonzero_initial_guess = false
 
 [time]
 
-run_length = 4
+run_length = 10
 #steps_per_year = 30
-total_steps = 100
+total_steps = 240
 #dt = 0.0333333I33
-num_sens = 2 #TODO rename
+num_sens = 5 #TODO rename
+
 
 [eigendec]
 
-num_eig = 10
+num_eig = 50
 eig_algo = "slepc"
 misfit_only = true
 
@@ -131,7 +132,7 @@ eigenvalue_thresh = 1.0e-1
 
 [errorprop]
 
-qoi = 'h2' #or 'vaf'
+qoi = 'vaf'
 
 [invsigma]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,6 +259,7 @@ def create_temp_model(request, mpi_tmpdir, case_gen, persist=False):
     from mpi4py import MPI
 
     tv = request.node.get_closest_marker("tv") is not None
+    key = request.node.get_closest_marker("key")
 
     tmpdir = mpi_tmpdir
     data_dir = pytest.data_dir
@@ -288,7 +289,8 @@ def create_temp_model(request, mpi_tmpdir, case_gen, persist=False):
         config['inversion']['verbose'] = False
 
         # If doing Taylor verification, only take 1 sample:
-        config['time']['num_sens'] = 1
+        if not key:
+            config['time']['num_sens'] = 1
 
         # and write out the toml to tmpdir
         with open(tmpdir/toml_file.name, 'w') as toml_out:


### PR DESCRIPTION
@jrmaddison 

I think I still need to work on this because the error_prop pytest pass but gives out a warning as I am only calculating very few eigenvalues (10), to keep the file size small... see warning below: 

```
=============================== warnings summary ===============================
tests/test_runs.py::test_run_smith_error_prop[4]
  /home/brecinos/fenics_ice/runs/run_errorprop.py:198: UserWarning: Data has no positive values, and therefore cannot be log-scaled.
    plt.savefig(os.path.join(str(diag_dir),

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========== 2 passed, 18 deselected, 1 warning in 230.35s (0:03:50) ============
```

Let me know @jrmaddison or @dngoldberg if there is a way of improving the eigendec composition to avoid the warning... 
The task still runs though so If you want to just test that `run_errorprop.py` works this is good enough.

The weird part is that if I run the test outside of pytest I dont get that warning. 

attempt to tackle issue #84 

