### PR TITLE
uncomment smith mark for smith test_inversion

### DIFF
--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -336,7 +336,7 @@ def test_run_invsigma(existing_temp_model, monkeypatch, setup_deps):
                               work_dir,
                               "expected_cntrl_sigma_prior_norm", tol=tol)
 
-#@pytest.mark.key('smith')
+@pytest.mark.key('smith')
 def test_run_smith_inversion(temp_model, monkeypatch):
 
     work_dir = temp_model["work_dir"]


### PR DESCRIPTION
Hello, 

I noticed I forgot to uncomment the mark for the smith glacier test inversion and  the test was running along with the rest of the test in the workflow. Maybe that was the problem? 

I think now the workflow will pass. 

Cheers
Bea  

