### PR TITLE
Cornford sliding law

### DIFF
--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -400,7 +400,7 @@ class MomsolveCfg(ConfigPrinter):
     Configuration of MomentumSolver with sensible defaults for picard & newton params
     """
 
-    quadrature_degree: int = 13
+    quadrature_degree: int = -1
     picard_params: dict = field(default_factory=lambda: {
         'nonlinear_solver': 'newton',
         'newton_solver': {'linear_solver': 'cg',

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -400,6 +400,7 @@ class MomsolveCfg(ConfigPrinter):
     Configuration of MomentumSolver with sensible defaults for picard & newton params
     """
 
+    quadrature_degree: int = 13
     picard_params: dict = field(default_factory=lambda: {
         'nonlinear_solver': 'newton',
         'newton_solver': {'linear_solver': 'cg',

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -389,7 +389,7 @@ class IceDynamicsCfg(ConfigPrinter):
 
     def __post_init__(self):
         """Check options valid"""
-        assert self.sliding_law in ['linear', 'budd']
+        assert self.sliding_law in ['linear', 'budd', 'corn']
         if self.min_thickness is not None:
             assert self.min_thickness >= 0.0
 

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -147,6 +147,7 @@ class model:
         self.bed_DG = Function(self.M2, name="bed_DG")
         self.H_DG.assign(project(self.H,self.M2))        
         self.bed_DG.assign(project(self.bed,self.M2))
+        # to come out if not used
         if (self.params.ice_dynamics.sliding_law == 'corn'):
             self.Umag_DG = Function(self.M2, name="Umag_DG")
 

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -147,9 +147,6 @@ class model:
         self.bed_DG = Function(self.M2, name="bed_DG")
         self.H_DG.assign(project(self.H,self.M2))        
         self.bed_DG.assign(project(self.bed,self.M2))
-        # to come out if not used
-        if (self.params.ice_dynamics.sliding_law == 'corn'):
-            self.Umag_DG = Function(self.M2, name="Umag_DG")
 
         self.gen_surf()  # surf = bed + thick
 
@@ -464,7 +461,7 @@ class model:
         if sl == 'linear':
             alpha = sqrt(B2)
 
-        elif (sl == 'budd' or sl == 'corn'):
+        elif sl  in ['budd','corn']:
             bed = self.bed
             H = self.H
             g = self.params.constants.g
@@ -490,6 +487,9 @@ class model:
                 # the weertman law (B2 = alpha^2 U^(-2/3)) only within a few km of the grounding line,
                 # we initialise based on the weertman sliding law
                 alpha = (1-fl_ex)*sqrt(B2 * U_mag**(2.0/3.0))
+
+        else:
+            raise RuntimeError(f"Invalid sliding law: '{sl:s}'")
 
         return alpha
 

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -476,6 +476,16 @@ class model:
             U_mag = sqrt(u_obs**2 + v_obs**2 + vel_rp**2)
             alpha = (1-fl_ex)*sqrt(B2 * ufl.Max(N, 0.01)**(-1.0/3.0) * U_mag**(2.0/3.0))
 
+        elif sl == 'corn'
+
+            # the relationship between alpha and B2 is too nontrivial to "invert", and an exact
+            # solution is not sought. Rather, since the sliding law is expected to deviate from 
+            # the weertman law (B2 = alpha^2 U^(-2/3)) only within a few km of the grounding line,
+            # we initialise based on the weertman sliding law
+            fl_ex = conditional(H <= H_flt, 1.0, 0.0)
+            U_mag = sqrt(u_obs**2 + v_obs**2 + vel_rp**2)
+            alpha = (1-fl_ex)*sqrt(B2 * U_mag**(2.0/3.0))
+
         return alpha
 
     def gen_alpha(self, a_bgd=500.0, a_lb=1e2, a_ub=1e4):

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -476,7 +476,7 @@ class model:
             U_mag = sqrt(u_obs**2 + v_obs**2 + vel_rp**2)
             alpha = (1-fl_ex)*sqrt(B2 * ufl.Max(N, 0.01)**(-1.0/3.0) * U_mag**(2.0/3.0))
 
-        elif sl == 'corn'
+        elif sl == 'corn':
 
             # the relationship between alpha and B2 is too nontrivial to "invert", and an exact
             # solution is not sought. Rather, since the sliding law is expected to deviate from 

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -92,6 +92,7 @@ class model:
             self.H_DG = None
             self.H_np = None
             self.surf = None
+            self.Umag_DG = None
 
         if init_vel_obs:
             # Load the velocity observations
@@ -145,7 +146,9 @@ class model:
         self.H_DG = Function(self.M2, name="H_DG")
         self.bed_DG = Function(self.M2, name="bed_DG")
         self.H_DG.assign(project(self.H,self.M2))        
-        self.bed_DG.assign(project(self.bed,self.M2))        
+        self.bed_DG.assign(project(self.bed,self.M2))
+        if (self.params.ice_dynamics.sliding_law == 'corn'):
+            self.Umag_DG = Function(self.M2, name="Umag_DG")
 
         self.gen_surf()  # surf = bed + thick
 
@@ -455,36 +458,37 @@ class model:
     def bdrag_to_alpha(self, B2):
         """Convert basal drag to alpha"""
         sl = self.params.ice_dynamics.sliding_law
+
+
         if sl == 'linear':
             alpha = sqrt(B2)
 
-        elif sl == 'budd':
+        elif (sl == 'budd' or sl == 'corn'):
             bed = self.bed
             H = self.H
             g = self.params.constants.g
             rhoi = self.params.constants.rhoi
             rhow = self.params.constants.rhow
+            H_flt = -rhow/rhoi * bed
             u_obs = self.u_obs_M
             v_obs = self.v_obs_M
             vel_rp = self.params.constants.vel_rp
 
             # Flotation Criterion
-            H_flt = -rhow/rhoi * bed
             fl_ex = conditional(H <= H_flt, 1.0, 0.0)
-
             N = (1-fl_ex)*(H*rhoi*g + ufl.Min(bed, 0.0)*rhow*g)
             U_mag = sqrt(u_obs**2 + v_obs**2 + vel_rp**2)
-            alpha = (1-fl_ex)*sqrt(B2 * ufl.Max(N, 0.01)**(-1.0/3.0) * U_mag**(2.0/3.0))
+            
+            if sl == 'budd':
+                alpha = (1-fl_ex)*sqrt(B2 * ufl.Max(N, 0.01)**(-1.0/3.0) * U_mag**(2.0/3.0))
 
-        elif sl == 'corn':
+            elif sl == 'corn':
 
-            # the relationship between alpha and B2 is too nontrivial to "invert", and an exact
-            # solution is not sought. Rather, since the sliding law is expected to deviate from 
-            # the weertman law (B2 = alpha^2 U^(-2/3)) only within a few km of the grounding line,
-            # we initialise based on the weertman sliding law
-            fl_ex = conditional(H <= H_flt, 1.0, 0.0)
-            U_mag = sqrt(u_obs**2 + v_obs**2 + vel_rp**2)
-            alpha = (1-fl_ex)*sqrt(B2 * U_mag**(2.0/3.0))
+                # the relationship between alpha and B2 is too nontrivial to "invert", and an exact
+                # solution is not sought. Rather, since the sliding law is expected to deviate from 
+                # the weertman law (B2 = alpha^2 U^(-2/3)) only within a few km of the grounding line,
+                # we initialise based on the weertman sliding law
+                alpha = (1-fl_ex)*sqrt(B2 * U_mag**(2.0/3.0))
 
         return alpha
 

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -516,7 +516,8 @@ class ssa_solver:
                 N_DG = (1-fl_ex)*(self.H_DG*rhoi*g + ufl.Min(self.bed_DG, 0.0)*rhow*g)
                 N_term = ufl.conditional(N > 0.0, N, 0)
                 N_DG_term = ufl.conditional(N_DG > 0.0, N_DG, 0)
-                denom_term = (C**3 * self.Umag_DG + (0.5 * N_DG_term)**3)**(1.0/3.0)
+#                denom_term = (C**3 * self.Umag_DG + (0.5 * N_DG_term)**3)**(1.0/3.0)
+                denom_term = (C**3 * U_mag + (0.5 * N_term)**3)**(1.0/3.0)
                 B2 = (1-fl_ex)*(C * 0.5 * N_term * U_mag**(-2.0/3.0) / denom_term)
             
         return B2

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -492,14 +492,27 @@ class ssa_solver:
         if sl == 'linear':
             B2 = C
 
-        elif sl == 'budd':
+        elif ((sl == 'budd') or (sl == 'corn')):
             N = (1-fl_ex)*(H*rhoi*g + ufl.Min(bed, 0.0)*rhow*g)
             U_mag = sqrt(U[0]**2 + U[1]**2 + vel_rp**2)
-            # Need to catch N <= 0.0 here, as it's raised to
-            # 1/3 (forward) and -2/3 (adjoint)
-            N_term = ufl.conditional(N > 0.0, N ** (1.0/3.0), 0)
-            B2 = (1-fl_ex)*(C * N_term * U_mag**(-2.0/3.0))
 
+            if sl == 'budd':
+                # Need to catch N <= 0.0 here, as it's raised to
+                # 1/3 (forward) and -2/3 (adjoint)
+                N_term = ufl.conditional(N > 0.0, N ** (1.0/3.0), 0)
+                B2 = (1-fl_ex)*(C * N_term * U_mag**(-2.0/3.0))
+
+            elif sl == 'corn':
+                # see eq 11 of Asay Davis et al, Experimental design for 
+                # three interrelated marine ice sheet and ocean model intercomparison projects ... 
+                # Geosci. Model Dev., 9, 2471–2497
+
+                # Need to catch N <= 0.0 here, as it's raised to
+                # 1/3 (forward) and -2/3 (adjoint)
+                N_term = ufl.conditional(N > 0.0, N, 0)
+                denom_term = (C**3 * U_mag + (0.5 * N_term)**3)**(1.0/3.0)
+                B2 = (1-fl_ex)*(C * 0.5 * N_term * U_mag**(-2.0/3.0) / denom_term)
+            
         return B2
 
     def solve_mom_eq(self, annotate_flag=None):

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -536,14 +536,24 @@ class ssa_solver:
         quad_degree = self.params.momsolve.quadrature_degree
         J_p = self.mom_Jac_p
 
+        dic_form = {"quadrature_degree": quad_degree}
 
-        momsolver = MomentumSolver(self.mom_F == 0,
+        if (quad_degree == -1):
+            momsolver = MomentumSolver(self.mom_F == 0,
+                                   self.U,
+                                   bcs=self.flow_bcs,
+                                   J_p=J_p,
+                                   picard_params=picard_params,
+                                   solver_parameters=newton_params)
+        else:
+            momsolver = MomentumSolver(self.mom_F == 0,
                                    self.U,
                                    bcs=self.flow_bcs,
                                    J_p=J_p,
                                    picard_params=picard_params,
                                    solver_parameters=newton_params,
                                    form_compiler_parameters={"quadrature_degree": quad_degree})
+
 
         momsolver.solve(annotate=annotate_flag)
 

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -29,6 +29,7 @@ from pathlib import Path
 import time
 import ufl
 import weakref
+from IPython import embed
 
 log = logging.getLogger("fenics_ice")
 
@@ -107,6 +108,7 @@ class ssa_solver:
         self.H_np = model.H_np
         self.H = model.H
         self.H_DG = model.H_DG
+        # to come out if not used
         if (self.params.ice_dynamics.sliding_law == 'corn'):
             self.Umag_DG = model.Umag_DG
         self.beta_bgd = model.beta_bgd
@@ -513,8 +515,10 @@ class ssa_solver:
                 # 1/3 (forward) and -2/3 (adjoint)
                 LocalProjectionSolver(H, self.H_DG).solve() 
                 LocalProjectionSolver(U_mag, self.Umag_DG).solve()
+                # to come out if not used
                 N_DG = (1-fl_ex)*(self.H_DG*rhoi*g + ufl.Min(self.bed_DG, 0.0)*rhow*g)
                 N_term = ufl.conditional(N > 0.0, N, 0)
+                # to come out if not used
                 N_DG_term = ufl.conditional(N_DG > 0.0, N_DG, 0)
 #                denom_term = (C**3 * self.Umag_DG + (0.5 * N_DG_term)**3)**(1.0/3.0)
                 denom_term = (C**3 * U_mag + (0.5 * N_term)**3)**(1.0/3.0)
@@ -529,14 +533,17 @@ class ssa_solver:
 
         newton_params = self.params.momsolve.newton_params
         picard_params = self.params.momsolve.picard_params
+        quad_degree = self.params.momsolve.quadrature_degree
         J_p = self.mom_Jac_p
+
 
         momsolver = MomentumSolver(self.mom_F == 0,
                                    self.U,
                                    bcs=self.flow_bcs,
                                    J_p=J_p,
                                    picard_params=picard_params,
-                                   solver_parameters=newton_params)
+                                   solver_parameters=newton_params,
+                                   form_compiler_parameters={"quadrature_degree": quad_degree})
 
         momsolver.solve(annotate=annotate_flag)
 

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -108,9 +108,6 @@ class ssa_solver:
         self.H_np = model.H_np
         self.H = model.H
         self.H_DG = model.H_DG
-        # to come out if not used
-        if (self.params.ice_dynamics.sliding_law == 'corn'):
-            self.Umag_DG = model.Umag_DG
         self.beta_bgd = model.beta_bgd
         self.bmelt = model.bmelt
         self.smb = model.smb
@@ -496,7 +493,7 @@ class ssa_solver:
         if sl == 'linear':
             B2 = C
 
-        elif ((sl == 'budd') or (sl == 'corn')):
+        elif sl in ['budd','corn']:
             U_mag = sqrt(U[0]**2 + U[1]**2 + vel_rp**2)
             N = (1-fl_ex)*(H*rhoi*g + ufl.Min(bed, 0.0)*rhow*g)
 
@@ -507,24 +504,20 @@ class ssa_solver:
                 B2 = (1-fl_ex)*(C * N_term * U_mag**(-2.0/3.0))
 
             elif sl == 'corn':
-                # see eq 11 of Asay Davis et al, Experimental design for 
+                # see eq 11 of Asay-Davis et al, Experimental design for 
                 # three interrelated marine ice sheet and ocean model intercomparison projects ... 
                 # Geosci. Model Dev., 9, 2471–2497
 
                 # Need to catch N <= 0.0 here, as it's raised to
                 # 1/3 (forward) and -2/3 (adjoint)
-                LocalProjectionSolver(H, self.H_DG).solve() 
-                LocalProjectionSolver(U_mag, self.Umag_DG).solve()
-                # to come out if not used
-                N_DG = (1-fl_ex)*(self.H_DG*rhoi*g + ufl.Min(self.bed_DG, 0.0)*rhow*g)
                 N_term = ufl.conditional(N > 0.0, N, 0)
-                # to come out if not used
-                N_DG_term = ufl.conditional(N_DG > 0.0, N_DG, 0)
-#                denom_term = (C**3 * self.Umag_DG + (0.5 * N_DG_term)**3)**(1.0/3.0)
                 denom_term = (C**3 * U_mag + (0.5 * N_term)**3)**(1.0/3.0)
                 B2 = (1-fl_ex)*(C * 0.5 * N_term * U_mag**(-2.0/3.0) / denom_term)
             
-        return B2
+            else:
+                raise RuntimeError(f"Invalid sliding law: '{sl:s}'")
+
+            return B2
 
     def solve_mom_eq(self, annotate_flag=None):
         """Solve the momentum equation defined in def_mom_eq"""
@@ -536,24 +529,13 @@ class ssa_solver:
         quad_degree = self.params.momsolve.quadrature_degree
         J_p = self.mom_Jac_p
 
-        dic_form = {"quadrature_degree": quad_degree}
-
-        if (quad_degree == -1):
-            momsolver = MomentumSolver(self.mom_F == 0,
-                                   self.U,
-                                   bcs=self.flow_bcs,
-                                   J_p=J_p,
-                                   picard_params=picard_params,
-                                   solver_parameters=newton_params)
-        else:
-            momsolver = MomentumSolver(self.mom_F == 0,
+        momsolver = MomentumSolver(self.mom_F == 0,
                                    self.U,
                                    bcs=self.flow_bcs,
                                    J_p=J_p,
                                    picard_params=picard_params,
                                    solver_parameters=newton_params,
-                                   form_compiler_parameters={"quadrature_degree": quad_degree})
-
+                                   form_compiler_parameters=None if quad_degree == -1 else {"quadrature_degree": quad_degree})
 
         momsolver.solve(annotate=annotate_flag)
 


### PR DESCRIPTION
This change implements an alternative sliding law, given by eq 11 of 

Asay-Davis, X. S., Cornford, S. L., Durand, G., Galton-Fenzi, B. K., Gladstone, R. M., Gudmundsson, G. H., Hattermann, T., Holland, D. M., Holland, D., Holland, P. R., Martin, D. F., Mathiot, P., Pattyn, F., and Seroussi, H.: Experimental design for three interrelated marine ice sheet and ocean model intercomparison projects: MISMIP v. 3 (MISMIP +), ISOMIP v. 2 (ISOMIP +) and MISOMIP v. 1 (MISOMIP1), Geosci. Model Dev., 9, 2471–2497, https://doi.org/10.5194/gmd-9-2471-2016, 2016.

The form of the equation is similar to the Budd sliding law, but it involves a denominator term. There are two end-members: where ice is near floatation, it asymptotes to a "Coulomb-plastic" law, where the yield stress is **independent** of the parameter alpha. Inland, it asymptotes to the commonly used **Weertman** sliding law, which is independent of effective stress *N*.

Main changes are to solver.sliding_law(), and the initialisation function model.bdrag_to_alpha() (the latter of which we have not used in the runs for the paper), and the sliding law is implemented by setting the toml parameter ice_dynamics.sliding_law to `'corn'` (for Stephen Cornford).

I have added a toml parameter `momsolve.quadrature_degree` in order to set the quadrature degree in the momentum solve, with a default -1 (in which case no manual order is passed). This is passed to the form compiler [here](https://github.com/dngoldberg/fenics_ice-1/blob/a63c7bfd6553722718e0b01544bda39c3960621e/fenics_ice/solver.py#L555), **the passing needs to be reviewed**.

_**This is still a work in progress.**_

All pytests pass, as none implement this sliding law. **However there are other things to consider.** 

I attempted two implementations: in one, the denominator is implemented with [only DG functions](https://github.com/dngoldberg/fenics_ice-1/blob/cac36323283e907a303535eaebb54ea2f33c21d4/fenics_ice/solver.py#L519).  In the other, i use [P1 functions](https://github.com/dngoldberg/fenics_ice-1/blob/cac36323283e907a303535eaebb54ea2f33c21d4/fenics_ice/solver.py#L520).

I have been able to run the run_taylor_inv.py script with the ice_stream (modified to implement this sliding law, and to have only alpha active). With sufficient convergence of the inversion, the P1 implementation passed the Taylor test. With the DG implementation, the Taylor performance was not as good. **However whether the inversion is run to convergence or not affects the orders found**

Additional pytests could be added, but first tv testing needs to be sorted (see issue 106).


