### PR TITLE
Generalize MPI communicator

### DIFF
--- a/fenics_ice/mesh.py
+++ b/fenics_ice/mesh.py
@@ -25,10 +25,9 @@ from .backend import FunctionSpace, Mesh, MeshFunction, MeshValueCollection, \
 from . import model
 
 import mpi4py.MPI as MPI  # noqa: N817
-import os
 import numpy as np
 from pathlib import Path
-import logging
+
 
 def get_mesh(params):
     """
@@ -40,7 +39,7 @@ def get_mesh(params):
     meshfile = Path(dd) / mesh_filename
     filetype = meshfile.suffix
 
-    #Ghost elements for DG in parallel
+    # Ghost elements for DG in parallel
     parameters['ghost_mode'] = 'shared_facet'
 
     assert mesh_filename
@@ -58,6 +57,7 @@ def get_mesh(params):
         raise ValueError("Don't understand the mesh filetype: %s" % meshfile.name)
 
     return mesh_in
+
 
 def get_mesh_length(mesh):
     """
@@ -79,6 +79,7 @@ def get_mesh_length(mesh):
     assert L1 == L2, 'Periodic Boundary Conditions require a square domain'
 
     return L1
+
 
 def get_periodic_space(params, mesh, deg=1, dim=1):
     """
@@ -108,6 +109,7 @@ def get_periodic_space(params, mesh, deg=1, dim=1):
         )
 
     return periodic_space
+
 
 def get_ff_from_file(params, model, fill_val=0):
     """

--- a/runs/run_invsigma.py
+++ b/runs/run_invsigma.py
@@ -22,7 +22,6 @@ import os
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["OPENBLAS_NUM_THREADS"] = "1"
 
-import mpi4py.MPI as MPI  # noqa: N817
 from pathlib import Path
 import pickle
 import numpy as np
@@ -44,7 +43,7 @@ def patch_fun(mesh_in, params):
     import random
     from scipy.spatial import KDTree
 
-    comm = MPI.COMM_WORLD
+    comm = mesh_in.mpi_comm()
     rank = comm.rank
     root = rank == 0
 
@@ -114,9 +113,6 @@ def patch_fun(mesh_in, params):
 
 def run_invsigma(config_file):
     """Compute control sigma values from eigendecomposition"""
-
-    comm = MPI.COMM_WORLD
-
     # Read run config file
     params = ConfigParser(config_file)
 
@@ -141,6 +137,7 @@ def run_invsigma(config_file):
 
     # Get model mesh
     mesh = fice_mesh.get_mesh(params)
+    comm = mesh.mpi_comm()
 
     # Define the model (only need alpha & beta though)
     mdl = model.model(mesh, input_data, params, init_fields=True)

--- a/runs/run_sample.py
+++ b/runs/run_sample.py
@@ -21,7 +21,6 @@ import os
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["OPENBLAS_NUM_THREADS"] = "1"
 
-import mpi4py.MPI as MPI  # noqa: N817
 import sys
 import numpy as np
 import pickle
@@ -77,6 +76,7 @@ def run_sample(config_file):
 
     # Get model mesh
     mesh = fice_mesh.get_mesh(params)
+    comm = mesh.mpi_comm()
 
     # Define the model
     mdl = model.model(mesh, input_data, params)
@@ -121,7 +121,7 @@ def run_sample(config_file):
             lam = lam[:max_lam] 
 
         y = Function(space)
-        with HDF5File(MPI.COMM_WORLD, str(outdir_e/vecfile), 'r') as hdf5data:
+        with HDF5File(comm, str(outdir_e/vecfile), 'r') as hdf5data:
             for i in range(len(lam)):
                 w = Function(space)
                 hdf5data.read(w, f'v/vector_{i}')

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -152,6 +152,7 @@ def test_writers(request, setup_deps, temp_model):
     toml_file = temp_model["toml_filename"]
 
     mdl = init_model(work_dir, toml_file)
+    comm = mdl.mesh.mpi_comm()
 
     # Create test function for writing
     space = mdl.Q
@@ -161,8 +162,8 @@ def test_writers(request, setup_deps, temp_model):
     vtkpath = inout.gen_path(mdl.params, "test", ".pvd")
     xdmfpath = vtkpath.with_suffix(".xdmf")
 
-    xdmfWriter = inout.XDMFWriter(xdmfpath, comm=mdl.mesh.mpi_comm())
-    vtkWriter = inout.VTKWriter(vtkpath, comm=mdl.mesh.mpi_comm())
+    xdmfWriter = inout.XDMFWriter(xdmfpath, comm=comm)
+    vtkWriter = inout.VTKWriter(vtkpath, comm=comm)
 
     # Check can write to file without error
     vtkWriter.write(test_fun, step=1)
@@ -181,8 +182,8 @@ def test_writers(request, setup_deps, temp_model):
 
     # New writers for unstepped output
 
-    xdmfWriter = inout.XDMFWriter(xdmfpath)
-    vtkWriter = inout.VTKWriter(vtkpath)
+    xdmfWriter = inout.XDMFWriter(xdmfpath, comm=comm)
+    vtkWriter = inout.VTKWriter(vtkpath, comm=comm)
 
     # Can't write unstepped to XDMF
     xdmfWriter.write(test_fun)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-# -*- coding: utf-8 -*-
-
 from fenics_ice.backend import Function, function_update_state, norm
 
 import pytest
@@ -24,6 +22,7 @@ import os
 import numpy as np
 import fenics_ice as fice
 from fenics_ice import model, config, inout, solver
+
 
 def init_model(model_dir, toml_file):
 
@@ -33,8 +32,6 @@ def init_model(model_dir, toml_file):
 
     # Get the relevant filenames from test case
     params = config.ConfigParser(toml_file, model_dir)
-    dd = params.io.input_dir
-    data_file = params.io.data_file
 
     # Read the input data & mesh
     indata = inout.InputData(params)
@@ -43,6 +40,7 @@ def init_model(model_dir, toml_file):
     # Create the model object
     return model.model(inmesh, indata, params,
                        init_fields=False, init_vel_obs=False)
+
 
 def initialize_fields(mdl):
     """Initialize data fields in model object"""
@@ -53,12 +51,15 @@ def initialize_fields(mdl):
     mdl.init_beta(mdl.bglen_to_beta(mdl.bglen),
                   mdl.params.inversion.beta_active)
 
+
 def initialize_vel_obs(mdl):
     """Initialize velocity observations"""
     mdl.vel_obs_from_data()
     mdl.init_lat_dirichletbc()
 
-### Tests below this point ###
+
+# Tests below this point
+
 
 @pytest.mark.dependency()
 def test_init_model(temp_model):
@@ -78,6 +79,7 @@ def test_init_model(temp_model):
 
     return mdl
 
+
 @pytest.mark.dependency()
 def test_initialize_fields(request, setup_deps, temp_model):
     """Attempt to initialize fields from HDF5 data file"""
@@ -93,7 +95,6 @@ def test_initialize_fields(request, setup_deps, temp_model):
 
     # Size of vectors in Q function space
     Q_size = mdl.Q.tabulate_dof_coordinates().shape[0]
-    M_size = mdl.M.tabulate_dof_coordinates().shape[0]
 
     assert mdl.bed.vector()[:].size == Q_size
     assert mdl.surf.vector()[:].size == Q_size
@@ -140,6 +141,7 @@ def test_gen_init_alpha(request, setup_deps, temp_model):
     pytest.check_float_result(alpha_norm,
                               expected_init_alpha,
                               work_dir, 'expected_init_alpha')
+
 
 @pytest.mark.dependency()
 def test_writers(request, setup_deps, temp_model):
@@ -193,6 +195,7 @@ def test_writers(request, setup_deps, temp_model):
     with pytest.raises(ValueError):
         xdmfWriter.write(test_fun, step=1)
 
+
 @pytest.mark.dependency()
 def test_control_separation(request, setup_deps, temp_model):
     """Check that mdl.alpha and slvr.alpha are distinct functions"""
@@ -226,13 +229,3 @@ def test_control_separation(request, setup_deps, temp_model):
 
     assert norm_as != norm_am
     assert norm_bs != norm_bm
-
-# Unused!
-def override_param(param_section, name, value):
-    """Override frozen ConfigParser params for testing"""
-    try:
-        param_section.__getattribute__(name)
-    except AttributeError:
-        raise
-
-    object.__setattr__(param_section, name, value)


### PR DESCRIPTION
Generalize the MPI communicator so that we no longer assume that MPI_COMM_WORLD is always the communicator in use.

Also
- Lint several files using flake8
- Remove some unused code
- Fix a minor bug in conftest.py (add a missing barrier)