### PR TITLE
fixing scipy dependency in GitHub actions

### DIFF
--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -49,12 +49,6 @@ jobs:
           micromamba list
           which python
           python -m pip install scipy==1.9.3
-#          ls $GITHUB_WORKSPACE
-#          cd $GITHUB_WORKSPACE/fenics_ice
-#          pip install -e .
-#          cd $GITHUB_WORKSPACE/tlm_adjoint
-#          pip install -e .
-#          micromamba info
 
       # We install fenics_ice and tlm_adjoint as developing modules
       - name: Install repositories as dev modules

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -48,7 +48,7 @@ jobs:
           micromamba info
           micromamba list
           which python
-          pip install scipy==1.9.3
+          python -m pip install scipy==1.9.3
           ls $GITHUB_WORKSPACE
           cd $GITHUB_WORKSPACE/fenics_ice
           pip install -e .

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -51,13 +51,13 @@ jobs:
       # We install fenics_ice and tlm_adjoint as developing modules
       - name: Install repositories as dev modules
         run: |
+          micromamba info
           ls $GITHUB_WORKSPACE
           cd $GITHUB_WORKSPACE/fenics_ice
           pwd
           pip install -e .
           cd $GITHUB_WORKSPACE/tlm_adjoint
           pip install -e .
-          micromamba info
           which python
 
       # Test fenics ice!

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -48,6 +48,8 @@ jobs:
           micromamba info
           micromamba list
           which python
+          pip uninstall scipy
+          pip install scipy==1.9.3
           ls $GITHUB_WORKSPACE
           cd $GITHUB_WORKSPACE/fenics_ice
           pip install -e .

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -51,23 +51,26 @@ jobs:
           ls $GITHUB_WORKSPACE
           cd $GITHUB_WORKSPACE/fenics_ice
           pip install -e .
+          cd $GITHUB_WORKSPACE/tlm_adjoint
+          pip install -e .
           micromamba info
 
       # We install fenics_ice and tlm_adjoint as developing modules
-      - name: Install repositories as dev modules
-        run: |
-          micromamba info
-          ls $GITHUB_WORKSPACE
-          cd $GITHUB_WORKSPACE/fenics_ice
-          pip install -e .
-          cd $GITHUB_WORKSPACE/tlm_adjoint
-          pip install -e .
+#      - name: Install repositories as dev modules
+#        run: |
+#          micromamba info
+#          ls $GITHUB_WORKSPACE
+#          cd $GITHUB_WORKSPACE/fenics_ice
+#          pip install -e .
+#          cd $GITHUB_WORKSPACE/tlm_adjoint
+#          pip install -e .
 
       # Test fenics ice!
       - name: Test fice
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/fenics_ice/
+          which python
           pytest -v --order-scope=module --color=yes
           mpirun -n 2 pytest -v --order-scope=module --color=yes
           mpirun -n 2 pytest -m key --key=smith --color=yes

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -48,7 +48,6 @@ jobs:
           micromamba info
           micromamba list
           which python
-          pip uninstall scipy
           pip install scipy==1.9.3
           ls $GITHUB_WORKSPACE
           cd $GITHUB_WORKSPACE/fenics_ice

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           micromamba info
           micromamba list
+          micromamba activate fenics_ice
 
       # We install fenics_ice and tlm_adjoint as developing modules
       - name: Install repositories as dev modules
@@ -56,6 +57,7 @@ jobs:
           pip install -e .
           cd $GITHUB_WORKSPACE/tlm_adjoint
           pip install -e .
+          which python
 
       # Test fenics ice!
       - name: Test fice

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -47,6 +47,11 @@ jobs:
         run: |
           micromamba info
           micromamba list
+          which python
+          ls $GITHUB_WORKSPACE
+          cd $GITHUB_WORKSPACE/fenics_ice
+          pip install -e .
+          micromamba info
 
       # We install fenics_ice and tlm_adjoint as developing modules
       - name: Install repositories as dev modules
@@ -54,11 +59,9 @@ jobs:
           micromamba info
           ls $GITHUB_WORKSPACE
           cd $GITHUB_WORKSPACE/fenics_ice
-          pwd
           pip install -e .
           cd $GITHUB_WORKSPACE/tlm_adjoint
           pip install -e .
-          which python
 
       # Test fenics ice!
       - name: Test fice

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -47,16 +47,17 @@ jobs:
         run: |
           micromamba info
           micromamba list
-          micromamba activate fenics_ice
 
       # We install fenics_ice and tlm_adjoint as developing modules
       - name: Install repositories as dev modules
         run: |
           ls $GITHUB_WORKSPACE
           cd $GITHUB_WORKSPACE/fenics_ice
+          pwd
           pip install -e .
           cd $GITHUB_WORKSPACE/tlm_adjoint
           pip install -e .
+          micromamba info
           which python
 
       # Test fenics ice!

--- a/.github/workflows/test-fice.yml
+++ b/.github/workflows/test-fice.yml
@@ -49,22 +49,23 @@ jobs:
           micromamba list
           which python
           python -m pip install scipy==1.9.3
+#          ls $GITHUB_WORKSPACE
+#          cd $GITHUB_WORKSPACE/fenics_ice
+#          pip install -e .
+#          cd $GITHUB_WORKSPACE/tlm_adjoint
+#          pip install -e .
+#          micromamba info
+
+      # We install fenics_ice and tlm_adjoint as developing modules
+      - name: Install repositories as dev modules
+        shell: bash -l {0}
+        run: |
           ls $GITHUB_WORKSPACE
           cd $GITHUB_WORKSPACE/fenics_ice
           pip install -e .
           cd $GITHUB_WORKSPACE/tlm_adjoint
           pip install -e .
           micromamba info
-
-      # We install fenics_ice and tlm_adjoint as developing modules
-#      - name: Install repositories as dev modules
-#        run: |
-#          micromamba info
-#          ls $GITHUB_WORKSPACE
-#          cd $GITHUB_WORKSPACE/fenics_ice
-#          pip install -e .
-#          cd $GITHUB_WORKSPACE/tlm_adjoint
-#          pip install -e .
 
       # Test fenics ice!
       - name: Test fice


### PR DESCRIPTION
I think there were two mistakes in test-fice.yml

1. Before installing the repositories with pip we needed to continue github actions commands with bash -l {0} in [test-fice.yml#L55](https://github.com/bearecinos/fenics_ice/blob/main/.github/workflows/test-fice.yml#L55):
```
    - name: Install repositories as dev modules
        shell: bash -l {0}
```
2. The smith glacier inversion test (and forward tests) was broken in the github server. Due to this issue still open in scipy:
https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html
and more info here:
https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html

So for now github actions scipy dependency is fix to a version < 1.10. I will fix this when the new release of scipy is out.
Apologies for the many commits I will try to squash them before merging them into the main branch 