### PR TITLE
Remove extra LU solver parameters

### DIFF
--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -641,10 +641,7 @@ class ssa_solver:
         H = self.H
         a, L = lhs(self.thickadv), rhs(self.thickadv)
         solve(a == L, H, bcs=self.H_bcs,
-              solver_parameters={"linear_solver": "lu",
-                                 "absolute_tolerance": 1e-10,
-                                 "relative_tolerance": 1e-11,
-              })  # Not sure these solver params are necessary (linear solve)
+              solver_parameters={"linear_solver": "lu"})
         LocalProjection(self.H_DG, H).solve() 
 
     def timestep(self, adjoint_flag=1, qoi_func=None ):


### PR DESCRIPTION
LU solvers do not require tolerances, and for a Krylov solver these would be specified under the `'krylov_solver'` parameter set.