### PR TITLE
MomentumSolver.forward_solve tidying

### DIFF
--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -1501,7 +1501,6 @@ class ddJ_wrapper(object):
 
 
 class MomentumSolver(EquationSolver):
-
     def __init__(self, *args, **kwargs):
         self.picard_params = kwargs.pop("picard_params", None)
         self.J_p = kwargs.pop("J_p", None)
@@ -1514,31 +1513,25 @@ class MomentumSolver(EquationSolver):
     def forward_solve(self, x, deps=None):
         if deps is None:
             deps = self.dependencies()
-            def replace_deps(form): return form  # noqa: E704
-        else:
-            from collections import OrderedDict
-            replace_map = OrderedDict(zip(self.dependencies(), deps))
-            replace_map[self.x()] = x
-            def replace_deps(form): return ufl.replace(form, replace_map)  # noqa: E704
-            # for i, (dep_x, dep) in enumerate(zip(self.dependencies(), deps)):
-            # info("%i %s %.16e" % (i, dep_x.name(), dep.vector().norm("l2")))
-        if self._initial_guess_index is not None:
-            function_assign(x, deps[self._initial_guess_index])
 
-        for i, bc in enumerate(self._bcs):
-            keys = bc.get_boundary_values().keys()
-            values = bc.get_boundary_values().items()
-            keys = list(keys)
-            import numpy
-            values = numpy.array(list(values))
-            info("BC %i %i %.16e" % (i, len(keys), (values * values).sum()))
+            def replace_deps(form):
+                return form
+        else:
+            replace_map = dict(zip(self.dependencies(), deps))
+            replace_map[self.x()] = x
+
+            def replace_deps(form):
+                return ufl.replace(form, replace_map)
 
         lhs = replace_deps(self._lhs)
-        rhs = 0 if self._rhs == 0 else replace_deps(self._rhs)
+        if isinstance(self._rhs, ufl.classes.Form):
+            rhs = replace_deps(self._rhs)
+        else:
+            rhs = self._rhs
+            assert isinstance(rhs, int) and rhs == 0
         J_p = replace_deps(self.J_p)
         J = replace_deps(self._J)
         # First order approx - inconsistent jacobian
-        # 'replace_deps' is only used by forward replay - tlm_adjoint stuff
         solve(lhs == rhs, x, self._bcs, J=J_p,
               form_compiler_parameters=self._form_compiler_parameters,
               solver_parameters=self.picard_params)


### PR DESCRIPTION
Remove access to long deprecated `_initial_guess_index`.

Also take the opportunity to tidy the code in `MomentumSolver.forward_solve`.
- Remove non-parallel-safe boundary condition diagnostic ouptut.
- Remove unsafe comparison of `self._rhs` with zero. This could create a UFL `Equation`.
- Remove unnecessary use of `OrderedDict` -- Python `dict`s have been ordered since 3.7.