### PR TITLE
Remove use of 'static'

### DIFF
--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -71,8 +71,8 @@ class model:
         # Define control functions
         # Note - these are potentially distinct from solver.alpha, .beta
         # because solver may use either two CG spaces or a mixed CGxCG space
-        self.alpha = Function(self.Qp, name='alpha', static=True)
-        self.beta = Function(self.Qp, name='beta', static=True)
+        self.alpha = Function(self.Qp, name='alpha')
+        self.beta = Function(self.Qp, name='beta')
         self.beta_bgd = Function(self.Qp, name='beta_bgd')
 
         # Default velocity mask and Beta fields
@@ -119,9 +119,9 @@ class model:
 
         min_thick = self.params.ice_dynamics.min_thickness
 
-        self.bed = self.field_from_data("bed", self.Q, static=True)
-        self.bmelt = self.field_from_data("bmelt", self.M, default=0.0, static=True)
-        self.smb = self.field_from_data("smb", self.M, default=0.0, static=True)
+        self.bed = self.field_from_data("bed", self.Q)
+        self.bmelt = self.field_from_data("bmelt", self.M, default=0.0)
+        self.smb = self.field_from_data("smb", self.M, default=0.0)
         self.H_np = self.field_from_data("thick", self.M, min_val=min_thick)
 
         if self.params.melt.use_melt_parameterisation:
@@ -348,17 +348,17 @@ class model:
                                       M_coords)
 
         # Define new functions to hold results
-        self.u_obs_Q = Function(self.Q, name="u_obs", static=True)
-        self.v_obs_Q = Function(self.Q, name="v_obs", static=True)
-        self.u_std_Q = Function(self.Q, name="u_std", static=True)
-        self.v_std_Q = Function(self.Q, name="v_std", static=True)
+        self.u_obs_Q = Function(self.Q, name="u_obs")
+        self.v_obs_Q = Function(self.Q, name="v_obs")
+        self.u_std_Q = Function(self.Q, name="u_std")
+        self.v_std_Q = Function(self.Q, name="v_std")
         # self.mask_vel_Q = Function(self.Q)
 
-        self.u_obs_M = Function(self.M, name="u_obs", static=True)
-        self.v_obs_M = Function(self.M, name="v_obs", static=True)
+        self.u_obs_M = Function(self.M, name="u_obs")
+        self.v_obs_M = Function(self.M, name="v_obs")
         # self.u_std_M = Function(self.M)
         # self.v_std_M = Function(self.M)
-        self.mask_vel_M = Function(self.M, name="mask_vel", static=True)
+        self.mask_vel_M = Function(self.M, name="mask_vel")
 
         # Fill via interpolation
         self.u_obs_Q.vector()[:] = interpolate(self.vel_obs['u_comp'], vtx_Q, wts_Q)

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -211,14 +211,14 @@ class ssa_solver:
         if self.mixed_space:
             assert self.params.inversion.dual  # only need mixed space for 2 controls
             self.QQ = self.get_mixed_space()
-            self._alphaXbeta = Function(self.QQ, name="alphaXbeta", static=True)
+            self._alphaXbeta = Function(self.QQ, name="alphaXbeta")
             self._cntrl_assigner = FunctionAssigner(self.QQ, [self.Qp]*2)
 
             self._alpha = None
             self._beta = None
         else:
-            self._alpha = Function(self.Qp, name='alpha', static=True)
-            self._beta = Function(self.Qp, name='beta', static=True)
+            self._alpha = Function(self.Qp, name='alpha')
+            self._beta = Function(self.Qp, name='beta')
 
             self.QQ = None
             self._alphaXbeta = None


### PR DESCRIPTION
The 'static' flag indicates that a `Constant` or `Function` will not be modified after it is used in the processed calculation. However this is not currently enforced by tlm_adjoint, which might lead to adjoint consistency bugs.

'cache' is a weaker promise, and tlm_adjoint will then correctly handle more cases where values are changed. However having looked at the use of 'static' in fenics_ice I don't think there is a significant performance benefit, and so this PR removes it.