### PR TITLE
Branch obs sensitivity

### DIFF
--- a/example_cases/ismipc_30x30/ismipc_30x30.sh
+++ b/example_cases/ismipc_30x30/ismipc_30x30.sh
@@ -13,8 +13,8 @@ cp output_momsolve/ismipc_U_obs.h5 input/
 
 #Run each phase of the model in turn
 RUN_DIR=$FENICS_ICE_BASE_DIR/runs/
-python $RUN_DIR/run_inv.py ismipc_30x30.toml
-python $RUN_DIR/run_forward.py ismipc_30x30.toml
-python $RUN_DIR/run_eigendec.py ismipc_30x30.toml
-python $RUN_DIR/run_errorprop.py ismipc_30x30.toml
-python $RUN_DIR/run_obs_sens_prop.py ismipc_30x30.toml
+#python $RUN_DIR/run_inv.py ismipc_30x30.toml
+#python $RUN_DIR/run_forward.py ismipc_30x30.toml
+#python $RUN_DIR/run_eigendec.py ismipc_30x30.toml
+#python $RUN_DIR/run_errorprop.py ismipc_30x30.toml
+mpirun -n 4 python $RUN_DIR/run_obs_sens_prop.py ismipc_30x30.toml

--- a/example_cases/ismipc_30x30/ismipc_30x30.sh
+++ b/example_cases/ismipc_30x30/ismipc_30x30.sh
@@ -17,4 +17,4 @@ python $RUN_DIR/run_inv.py ismipc_30x30.toml
 python $RUN_DIR/run_forward.py ismipc_30x30.toml
 python $RUN_DIR/run_eigendec.py ismipc_30x30.toml
 python $RUN_DIR/run_errorprop.py ismipc_30x30.toml
-python $RUN_DIR/run_invsigma.py ismipc_30x30.toml
+python $RUN_DIR/run_obs_sens_prop.py ismipc_30x30.toml

--- a/example_cases/ismipc_30x30/ismipc_30x30.toml
+++ b/example_cases/ismipc_30x30/ismipc_30x30.toml
@@ -32,7 +32,7 @@ random_seed = 0
 [mesh]
 
 mesh_filename = "ismip_mesh.xml"
-periodic_bc = true
+periodic_bc = false
 
 [obs]
 
@@ -67,7 +67,8 @@ sliding_law = 'linear' #budd, linear
 [momsolve.picard_params]
 nonlinear_solver = "newton"
 [momsolve.picard_params.newton_solver]
-linear_solver = "umfpack"
+linear_solver = "cg"
+preconditioner = "hypre_amg"
 maximum_iterations = 200
 absolute_tolerance = 1.0e-0
 relative_tolerance = 1.0e-3
@@ -77,7 +78,9 @@ error_on_nonconvergence =  false
 [momsolve.newton_params]
 nonlinear_solver = "newton"
 [momsolve.newton_params.newton_solver]
-linear_solver = "umfpack"
+#linear_solver = "umfpack"
+linear_solver = "cg"
+preconditioner = "hypre_amg"
 maximum_iterations = 25
 absolute_tolerance = 1.0e-7
 relative_tolerance = 1.0e-8

--- a/example_cases/ismipc_30x30/ismipc_30x30.toml
+++ b/example_cases/ismipc_30x30/ismipc_30x30.toml
@@ -128,6 +128,10 @@ qoi = 'h2' #or 'vaf'
     name = "Bottom Edge"
     id = 4
 
+[mass_solve]
+
+use_cg_thickness = true
+
 [testing]
 
 expected_init_alpha = 531.6114524861194

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -124,6 +124,19 @@ class ConfigParser(object):
         except KeyError:
             pass
 
+        try:
+            obs_sens_dict = self.config_dict['obs_sens']
+        except KeyError:
+            obs_sens_dict = {}
+        self.obs_sens = ObsSensCfg(**obs_sens_dict)
+
+        try:
+            mass_solve_dict = self.config_dict['mass_solve']
+        except KeyError:
+            mass_solve_dict = {}
+        self.mass_solve = MassSolveCfg(**mass_solve_dict)
+
+
     def check_dirs(self):
         """
         Check input directory exists & create output dir if necessary.
@@ -138,13 +151,15 @@ class ConfigParser(object):
                     self.time.phase_name,
                     self.eigendec.phase_name,
                     self.error_prop.phase_name,
-                    self.inv_sigma.phase_name]
+                    self.inv_sigma.phase_name,
+                    self.obs_sens.phase_name]
 
         ph_suffix = [self.inversion.phase_suffix,
                     self.time.phase_suffix,
                     self.eigendec.phase_suffix,
                     self.error_prop.phase_suffix,
-                    self.inv_sigma.phase_suffix]
+                    self.inv_sigma.phase_suffix,
+                    self.obs_sens.phase_suffix]
 
         for ph, suff in zip(ph_names, ph_suffix):
             out_dir = (outdir / ph / suff)
@@ -252,6 +267,17 @@ class ErrorPropCfg(ConfigPrinter):
     qoi: str = 'vaf'
     phase_name: str = 'error_prop'
     phase_suffix: str = ''
+
+
+@dataclass(frozen=True)
+class ObsSensCfg(ConfigPrinter):
+    """
+    Configuration related to observation sensitivities
+    """
+    qoi: str = 'vaf'
+    phase_name: str = 'obs_sens'
+    phase_suffix: str = ''
+    
 
 @dataclass(frozen=True)
 class SampleCfg(ConfigPrinter):
@@ -395,6 +421,18 @@ class IceDynamicsCfg(ConfigPrinter):
 
 
 @dataclass(frozen=True)
+class MassSolveCfg(ConfigPrinter):
+    """
+    Options for mass balance solver
+    """
+
+    use_cg_thickness: bool = False
+
+    def __post_init__(self):
+     """  """
+
+
+@dataclass(frozen=True)
 class MomsolveCfg(ConfigPrinter):
     """
     Configuration of MomentumSolver with sensible defaults for picard & newton params
@@ -513,7 +551,6 @@ class IOCfg(ConfigPrinter):
 
         for fname in fname_default_suff:
             self.set_default_filename(fname, fname_default_suff[fname])
-            #embed()
 
 @dataclass(frozen=True)
 class TimeCfg(ConfigPrinter):

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -294,7 +294,6 @@ def write_variable(var, params, name=None, outdir=None, phase_name='', phase_suf
     outvar.rename(name, "")
     # Prefix the run name
     outfname = Path(outdir) / phase_name / phase_suffix / "_".join((params.io.run_name+phase_suffix, name))
-    #embed()
 
     # Write out output according to user specified format in toml
     output_var_format = params.io.output_var_format

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -34,6 +34,11 @@ log = logging.getLogger("fenics_ice")
         # TODO - this will not handle extrapolation/missing data
         # nicely - unfound simplex are returned '-1' which takes the last
         # tri.simplices...
+
+        # at the moment i have moved these from vel_obs_from_data, so they 
+        # can be called directly from a run script.
+        # the ismipc test, which calls this function, still seems to perform fine
+        # but this refactoring may make things less efficient.
 def interp_weights(xy, uv, periodic_bc, d=2):
             """Compute the nearest vertices & weights (for reuse)"""
             from scipy.spatial import Delaunay

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -26,7 +26,6 @@ import numpy as np
 from pathlib import Path
 from numpy.random import randn
 import logging
-from IPython import embed
 
 log = logging.getLogger("fenics_ice")
 
@@ -156,7 +155,10 @@ class model:
         self.bed = self.field_from_data("bed", self.Q)
         self.bmelt = self.field_from_data("bmelt", self.M, default=0.0)
         self.smb = self.field_from_data("smb", self.M, default=0.0)
-        self.H_np = self.field_from_data("thick", self.M, min_val=min_thick)
+        if (self.params.mass_solve.use_cg_thickness and self.params.mesh.periodic_bc):
+         self.H_np = self.field_from_data("thick", self.Qp, min_val=min_thick)
+        else:
+         self.H_np = self.field_from_data("thick", self.M, min_val=min_thick)
 
         if self.params.melt.use_melt_parameterisation:
        

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -82,7 +82,7 @@ def Amat_obs_action(P, Rvec, vec_cg, dg_space):
 
     test, trial = TestFunction(dg_space), TrialFunction(dg_space)
     vec_dg = Function(dg_space)
-    solve(inner(trial, test) * dx == inner(vec_cg, vec_dg) * dx,
+    solve(inner(trial, test) * dx == inner(vec_cg, test) * dx,
           vec_dg, solver_parameters={"linear_solver": "lu"})
     
     return Rvec * (P @ vec_dg.vector().get_local())

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -1322,8 +1322,8 @@ class ssa_solver:
                 = (interp_space,
                    u_PRP, v_PRP, l_u_obs, l_v_obs, J_u_obs, J_v_obs)
             if (self.obs_sensitivity): 
-                self._cached_Amat_vars = \ 
-                (P, u_std_local, v_std_local, interp_space)
+                self._cached_Amat_vars = \
+                    (P, u_std_local, v_std_local, interp_space)
 
         (interp_space,
          u_PRP, v_PRP, l_u_obs, l_v_obs, J_u_obs, J_v_obs) = \

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -1333,7 +1333,7 @@ class ssa_solver:
                    u_PRP, v_PRP, l_u_obs, l_v_obs, J_u_obs, J_v_obs)
             if (self.obs_sensitivity):
                 self._cached_Amat_vars = \
-                    (P, u_std_local, v_std_local, interp_space)
+                    (P, u_std_local, v_std_local, obs_local, interp_space)
 
         (interp_space,
          u_PRP, v_PRP, l_u_obs, l_v_obs, J_u_obs, J_v_obs) = \

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -77,7 +77,11 @@ def interpolation_matrix(x_coords, y_space):
 
 
 def Amat_obs_action(P, Rvec, vec_cg, dg_space):
+    # This function implements the Rvec*P*D action on a P1 function
+    #  where D is a projection into DG space
+    # 
     # to be called for each component of velocity
+    #
 
     test, trial = TestFunction(dg_space), TrialFunction(dg_space)
     vec_dg = Function(dg_space)

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -92,7 +92,7 @@ class ssa_solver:
     """
     The ssa_solver object is currently the only kind of fenics_ice 'solver' available.
     """
-    def __init__(self, model, mixed_space=False):
+    def __init__(self, model, mixed_space=False, obs_sensitivity=False):
 
         # Enable aggressive compiler options
         parameters["form_compiler"]["optimize"] = False
@@ -104,6 +104,7 @@ class ssa_solver:
         self.model.solvers.append(self)
         self.params = model.params
         self.mixed_space = mixed_space
+        self.obs_sensitivity = obs_sensitivity
 
         # Mesh/Function Spaces
         self.mesh = model.mesh
@@ -1314,10 +1315,15 @@ class ssa_solver:
                 J_v_obs, op=MPI.SUM)
             J_v_obs, = J_v_obs
 
+            u_std_local = u_std[obs_local]
+            v_std_local = v_std[obs_local]
+
             self._cached_J_mismatch_data \
                 = (interp_space,
                    u_PRP, v_PRP, l_u_obs, l_v_obs, J_u_obs, J_v_obs)
-            self._cached_P_matrix = P   
+            if (self.obs_sensitivity): 
+                self._cached_Amat_vars = \ 
+                (P, u_std_local, v_std_local, interp_space)
 
         (interp_space,
          u_PRP, v_PRP, l_u_obs, l_v_obs, J_u_obs, J_v_obs) = \

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -29,7 +29,6 @@ from pathlib import Path
 import time
 import ufl
 import weakref
-from IPython import embed
 
 log = logging.getLogger("fenics_ice")
 

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -77,6 +77,17 @@ def interpolation_matrix(x_coords, y_space):
     return x_local, P
 
 
+def Amat_obs_action(P, Rvec, vec_cg, dg_space):
+    # to be called for each component of velocity
+
+    test, trial = TestFunction(dg_space), TrialFunction(dg_space)
+    vec_dg = Function(dg_space)
+    solve(inner(trial, test) * dx == inner(vec_cg, vec_dg) * dx,
+          vec_dg, solver_parameters={"linear_solver": "lu"})
+    
+    return Rvec * (P @ vec_dg.vector().get_local())
+    
+
 class ssa_solver:
     """
     The ssa_solver object is currently the only kind of fenics_ice 'solver' available.
@@ -1306,6 +1317,8 @@ class ssa_solver:
             self._cached_J_mismatch_data \
                 = (interp_space,
                    u_PRP, v_PRP, l_u_obs, l_v_obs, J_u_obs, J_v_obs)
+            self._cached_P_matrix = P   
+
         (interp_space,
          u_PRP, v_PRP, l_u_obs, l_v_obs, J_u_obs, J_v_obs) = \
             self._cached_J_mismatch_data

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -29,6 +29,7 @@ from pathlib import Path
 import time
 import ufl
 import weakref
+from IPython import embed
 
 log = logging.getLogger("fenics_ice")
 
@@ -159,7 +160,7 @@ class ssa_solver:
         self.Phi = TestFunction(self.V)
         self.pTau = TestFunction(self.Qp)
 
-        if (self.params.mass_solve.use_cg_thickness and self.params.mesh.periodic_bc):
+        if not (self.params.mass_solve.use_cg_thickness and self.params.mesh.periodic_bc):
          self.trial_H = TrialFunction(self.M)
          self.Ksi = TestFunction(self.M)
         else:
@@ -631,14 +632,14 @@ class ssa_solver:
         )
 
 
-        if not (self.params.mass_solve.cg_thickness and self.params.mesh.periodic_bc):
+        if not (self.params.mass_solve.use_cg_thickness and self.params.mesh.periodic_bc):
             self.thickadv = self.thickadv + (
 
             # Outflow at boundaries
                 + conditional(dot(U_np, nm) > 0, 1.0, 0.0)*inner(Ksi, dot(U_np * trial_H, nm))
                 * ds
 
-            # Inflow at boundaries
+           # Inflow at boundaries
                 + conditional(dot(U_np, nm) < 0, 1.0, 0.0)*inner(Ksi, dot(U_np * H_init, nm))
                 * ds
             )

--- a/runs/run_forward.py
+++ b/runs/run_forward.py
@@ -31,7 +31,7 @@ from fenics_ice.config import ConfigParser
 import fenics_ice.fenics_util as fu
 
 import matplotlib as mpl
-#mpl.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import datetime
@@ -73,21 +73,8 @@ def run_forward(config_file):
     # Run the forward model
     Q = slvr.timestep(adjoint_flag=1, qoi_func=qoi_func)
 
-    x    = mesh.coordinates()[:,0]
-    y    = mesh.coordinates()[:,1]
-    t    = mesh.cells()
-    cmap_div='RdBu'
-    V = slvr.H
-    v   = V.compute_vertex_values(mesh)
-    plt.tricontourf(x, y, t, v, cmap=plt.get_cmap(cmap_div))
-    plt.show()
-
     # Run the adjoint model, computing gradient of Qoi w.r.t cntrl
     dQ_ts = compute_gradient(Q, cntrl)  # Isaac 27
-    V = dQ_ts[-1][0]
-    v   = V.compute_vertex_values(mesh)
-    plt.tricontourf(x, y, t, v, cmap=plt.get_cmap(cmap_div))
-    plt.show()
 
     # Output model variables in ParaView+Fenics friendly format
     # Output QOI & DQOI (needed for next steps)

--- a/runs/run_forward.py
+++ b/runs/run_forward.py
@@ -31,7 +31,7 @@ from fenics_ice.config import ConfigParser
 import fenics_ice.fenics_util as fu
 
 import matplotlib as mpl
-mpl.use("Agg")
+#mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import datetime
@@ -72,8 +72,22 @@ def run_forward(config_file):
 
     # Run the forward model
     Q = slvr.timestep(adjoint_flag=1, qoi_func=qoi_func)
+
+    x    = mesh.coordinates()[:,0]
+    y    = mesh.coordinates()[:,1]
+    t    = mesh.cells()
+    cmap_div='RdBu'
+    V = slvr.H
+    v   = V.compute_vertex_values(mesh)
+    plt.tricontourf(x, y, t, v, cmap=plt.get_cmap(cmap_div))
+    plt.show()
+
     # Run the adjoint model, computing gradient of Qoi w.r.t cntrl
     dQ_ts = compute_gradient(Q, cntrl)  # Isaac 27
+    V = dQ_ts[-1][0]
+    v   = V.compute_vertex_values(mesh)
+    plt.tricontourf(x, y, t, v, cmap=plt.get_cmap(cmap_div))
+    plt.show()
 
     # Output model variables in ParaView+Fenics friendly format
     # Output QOI & DQOI (needed for next steps)

--- a/runs/run_inv.py
+++ b/runs/run_inv.py
@@ -34,6 +34,7 @@ from fenics_ice.config import ConfigParser
 # import numpy as np
 # import pickle
 import datetime
+from IPython import embed
 
 def run_inv(config_file):
     """Run the inversion part of the simulation"""

--- a/runs/run_inv.py
+++ b/runs/run_inv.py
@@ -34,7 +34,6 @@ from fenics_ice.config import ConfigParser
 # import numpy as np
 # import pickle
 import datetime
-from IPython import embed
 
 def run_inv(config_file):
     """Run the inversion part of the simulation"""

--- a/runs/run_obs_sens_prop.py
+++ b/runs/run_obs_sens_prop.py
@@ -158,6 +158,14 @@ def run_obs_sens_prop(config_file):
     # -- exceptions are the defined function compute_tau() and 
     # -- the call to solver.forward() to generate interpolation matrix
 
+    # below this point the result
+    #
+    # dQ/d\hat{p} = A (dp/dm) H^{-1} dQ_T/dm
+    #  
+    # is calculated, where p and \hat{p} are components of velocity (modelled and observed, respectively)
+    # Q_T is the QoI at a certain time, and A is a product of several operators involving interpolation, 
+    # projection, and observational covariance.
+
     # this simply loads cached variables from solver.py which are cached in 
     #  the above forward() call
     assert hasattr(slvr,'_cached_Amat_vars'),\

--- a/runs/run_obs_sens_prop.py
+++ b/runs/run_obs_sens_prop.py
@@ -20,18 +20,6 @@ from tlm_adjoint import reset_manager, set_manager, stop_manager, \
         configure_tlm, function_tlm, restore_manager,\
         EquationManager, start_manager
 
-@restore_manager
-def compute_tau(forward, u, m, dm):
-    # this block of code will do the "forward" (calculation of velocity and cost function) once
-    # and then find the jacobian of u in the direction needed
-    set_manager(EquationManager(cp_method="none", cp_parameters={}))
-    stop_manager()
-
-    start_manager(tlm=True)
-    configure_tlm((m, dm))
-    forward(m)
-    return function_tlm(u, (m, dm))        
-
 import os
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["OPENBLAS_NUM_THREADS"] = "1"
@@ -53,6 +41,18 @@ mpl.use("Agg")
 import matplotlib.pyplot as plt
 from IPython import embed
 from scipy.sparse import spdiags
+
+@restore_manager
+def compute_tau(forward, u, m, dm):
+    # this block of code will do the "forward" (calculation of velocity and cost function) once
+    # and then find the jacobian of u in the direction needed
+    set_manager(EquationManager(cp_method="none", cp_parameters={}))
+    stop_manager()
+
+    start_manager(tlm=True)
+    configure_tlm((m, dm))
+    forward(m)
+    return function_tlm(u, (m, dm))        
 
 
 def run_obs_sens_prop(config_file):

--- a/runs/run_obs_sens_prop.py
+++ b/runs/run_obs_sens_prop.py
@@ -1,0 +1,202 @@
+# For fenics_ice copyright information see ACKNOWLEDGEMENTS in the fenics_ice
+# root directory
+
+# This file is part of fenics_ice.
+#
+# fenics_ice is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# fenics_ice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
+
+from fenics_ice.backend import Function, HDF5File
+
+import os
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+
+import mpi4py.MPI as MPI  # noqa: N817
+from pathlib import Path
+import pickle
+import numpy as np
+import sys
+
+from fenics_ice import model, solver, inout
+from fenics_ice import mesh as fice_mesh
+from fenics_ice.config import ConfigParser
+
+import matplotlib as mpl
+mpl.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def run_errorprop(config_file):
+
+    # Read run config file
+    params = ConfigParser(config_file)
+
+    # Setup logging
+    inout.setup_logging(params)
+    inout.log_preamble("errorprop", params)
+
+    outdir = params.io.output_dir
+
+    # Load the static model data (geometry, smb, etc)
+    input_data = inout.InputData(params)
+
+    # Eigen decomposition params
+    phase_eigen = params.eigendec.phase_name
+    phase_suffix_e = params.eigendec.phase_suffix
+    lamfile = params.io.eigenvalue_file
+    vecfile = params.io.eigenvecs_file
+
+    # Qoi forward params
+    phase_time = params.time.phase_name
+    phase_suffix_qoi = params.time.phase_suffix
+    dqoi_h5file = params.io.dqoi_h5file
+
+    if len(phase_suffix_e) > 0:
+        lamfile = params.io.run_name + phase_suffix_e + '_eigvals.p'
+        vecfile = params.io.run_name + phase_suffix_e + '_vr.h5'
+    if len(phase_suffix_qoi) > 0:
+        dqoi_h5file = params.io.run_name + phase_suffix_qoi + '_dQ_ts.h5'
+
+    # Get model mesh
+    mesh = fice_mesh.get_mesh(params)
+
+    # Define the model
+    mdl = model.model(mesh, input_data, params)
+
+    # Load alpha/beta fields
+    mdl.alpha_from_inversion()
+    mdl.beta_from_inversion()
+    mdl.bglen_from_data(mask_only=True)
+
+    # Setup our solver object
+    slvr = solver.ssa_solver(mdl, mixed_space=params.inversion.dual, obs_sensitivity=True)
+
+    # from errorprop -- this variable is not used in that fn
+    #cntrl = slvr.get_control()[0]
+
+    cntrl = slvr.get_control()
+    space = slvr.get_control_space()
+
+    # Regularization operator using inversion delta/gamma values
+    Prior = mdl.get_prior()
+    reg_op = Prior(slvr, space)
+
+    # Loads eigenvalues from file
+    outdir_e = Path(outdir)/phase_eigen/phase_suffix_e
+    with open(outdir_e/lamfile, 'rb') as ff:
+        eigendata = pickle.load(ff)
+        lam = eigendata[0].real.astype(np.float64)
+        nlam = len(lam)
+
+    # Check if eigendecomposition successfully produced num_eig
+    # or if some are NaN
+    if np.any(np.isnan(lam)):
+        raise RuntimeError("NaN eigenvalue(s)")
+
+    # and eigenvectors from .h5 file
+    eps = params.constants.float_eps
+    W = []
+    with HDF5File(MPI.COMM_WORLD, str(outdir_e/vecfile), 'r') as hdf5data:
+        for i in range(nlam):
+            w = Function(space)
+            hdf5data.read(w, f'v/vector_{i}')
+
+            # Test squared norm in prior == 1.0
+            B_inv_w = Function(space, space_type="conjugate_dual")
+            reg_op.action(w.vector(), B_inv_w.vector())
+            norm_sq_in_prior = w.vector().inner(B_inv_w.vector())
+            assert (abs(norm_sq_in_prior - 1.0) < eps)
+            del B_inv_w
+
+            W.append(w)
+
+    D = np.diag(lam / (lam + 1))  # D_r Isaac 20
+
+    # File containing dQoi_dCntrl (i.e. Jacobian of parameter to observable (Qoi))
+    outdir_qoi = Path(outdir)/phase_time/phase_suffix_qoi
+    hdf5data = HDF5File(MPI.COMM_WORLD, str(outdir_qoi/dqoi_h5file), 'r')
+
+    dQ_cntrl = Function(space, space_type="conjugate_dual")
+
+    run_length = params.time.run_length
+    num_sens = params.time.num_sens
+    t_sens = np.flip(np.linspace(run_length, 0, num_sens))
+
+    if hasattr(slvr,'_cached_Amat_vars'):
+        (P, u_std_local, v_std_local, interp_space) = \
+                self._cached_Amat_vars
+    else:
+        logging.error("Attempt to retrieve Amat from solver type without first caching")
+        raise Exception
+
+    Ru = spdiags(1.0 / (u_std[obs_local] ** 2),
+                              0, P.shape[0], P.shape[0])
+    Rv = spdiags(1.0 / (v_std[obs_local] ** 2),
+                              0, P.shape[0], P.shape[0])
+
+    dObs = []
+
+    for j in range(num_sens):
+        hdf5data.read(dQ_cntrl, f'dQd{cntrl.name()}/vector_{j}')
+
+        tmp1 = np.asarray([w.vector().inner(dQ_cntrl.vector()) for w in W])
+        tmp2 = np.dot(D, tmp1)
+
+        P1 = Function(space)
+        for tmp, w in zip(tmp2, W):
+            P1.vector().axpy(tmp, w.vector())
+
+        P2 = Function(space)
+        reg_op.inv_action(dQ_cntrl.vector(), P2.vector())
+
+        P3 = Function(space)
+        P3.vector() = P2.vector() - P1.vector()
+
+    # this block of code will do the "forward" (calculation of velocity and cost function) once
+    # and then find the jacobian of u in the direction needed
+    # im not sure which of these commands need be repeated and which can only be done once
+        reset_manager()
+        stop_manager(tlm=False)
+        configure_tml((cntrl, P3))
+        slvr.forward(cntrl)
+        tau = function_tml(solver.U, (cntrl, P3))
+
+    # tau is in the space of U (right?)
+        tauu, tauv = split(tau)
+
+    # this block of code then implements -A.tau
+
+        dobs = slvr.Amat_obs_action(P, Ru, tauu, interp_space) + \
+               slvr.Amat_obs_action(P, Rv, tauv, interp_space)
+        dObs.append(dobs)
+               
+    # Look at the last sampled time and check how sigma QoI converges
+    # with addition of more eigenvectors
+
+    # Save plots in diagnostics
+    phase_err = params.error_prop.phase_name
+    phase_suffix_err = params.error_prop.phase_suffix
+    diag_dir = Path(params.io.diagnostics_dir)/phase_err/phase_suffix_err
+    outdir_err = Path(params.io.output_dir)/phase_err/phase_suffix_err
+
+
+    #with open( os.path.join(outdir_err, sigma_file), "wb" ) as sigfile:
+    #    pickle.dump( [sigma, t_sens], sigfile)
+    #with open( os.path.join(outdir_err, sigma_prior_file), "wb" ) as sigpfile:
+    #    pickle.dump( [sigma_prior, t_sens], sigpfile)
+
+
+
+if __name__ == "__main__":
+    assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"
+    run_errorprop(sys.argv[1])

--- a/runs/run_obs_sens_prop.py
+++ b/runs/run_obs_sens_prop.py
@@ -29,7 +29,6 @@ import numpy as np
 import sys
 
 from fenics_ice import model, solver, inout
-from fenics_ice.model import interp_weights, interpolate
 from fenics_ice import mesh as fice_mesh
 from fenics_ice.config import ConfigParser
 from ufl import split
@@ -181,11 +180,6 @@ def run_obs_sens_prop(config_file):
 
     dObsU = []
     dObsV = []
-    dObsU_M = []
-    dObsV_M = []
-
-    M_coords = mdl.M.tabulate_dof_coordinates()
-    vtx_M, wts_M = interp_weights(mdl.vel_obs['uv_obs_pts'],M_coords, params.mesh.periodic_bc)
 
     comm = MPI.COMM_WORLD
     size = comm.Get_size()
@@ -261,12 +255,6 @@ def run_obs_sens_prop(config_file):
 
         dObsU.append(dobsU)
         dObsV.append(dobsV)
-
-        # this is simply interpolation for later visualisation
-        dObsU_M.append(Function(mdl.M))
-        dObsV_M.append(Function(mdl.M))
-        dObsU_M[j].vector()[:] = interpolate(dobsU, vtx_M, wts_M)
-        dObsV_M[j].vector()[:] = interpolate(dobsV, vtx_M, wts_M)
 
 
     # Save data in diagnostics

--- a/runs/run_obs_sens_prop.py
+++ b/runs/run_obs_sens_prop.py
@@ -38,7 +38,7 @@ from ufl import split
 from fenics_ice.solver import Amat_obs_action
 
 import matplotlib as mpl
-mpl.use("Agg")
+#mpl.use("Agg")
 import matplotlib.pyplot as plt
 from IPython import embed
 from scipy.sparse import spdiags
@@ -216,7 +216,64 @@ def run_obs_sens_prop(config_file):
         dObsV_M[j].vector()[:] = interpolate(dobsv, vtx_M, wts_M)
 
 
+    x    = mesh.coordinates()[:,0]
+    y    = mesh.coordinates()[:,1]
+    t    = mesh.cells()
+    cmap_div='RdBu'
 
+    fig = plt.figure(figsize=(10,10))
+    
+    V = mdl.u_obs_M
+    ax  = fig.add_subplot(221)
+    ax.set_aspect('equal')
+    v   = V.compute_vertex_values(mesh)
+    ticks = np.linspace(10,30,3)
+    c = ax.tricontourf(x, y, t, v, cmap=plt.get_cmap(cmap_div))
+    cbar = plt.colorbar(c, ticks=ticks, pad=0.05)
+
+    V = mdl.v_obs_M
+    ax  = fig.add_subplot(222)
+    ax.set_aspect('equal')
+    v   = V.compute_vertex_values(mesh)
+    ticks = np.linspace(10,30,3)
+    c = ax.tricontourf(x, y, t, v, cmap=plt.get_cmap(cmap_div))
+    cbar = plt.colorbar(c, ticks=ticks, pad=0.05)
+
+    numlev = 20
+    tick_options = {'axis':'both','which':'both','bottom':False,
+        'top':False,'left':False,'right':False,'labelleft':False, 'labelbottom':False}
+
+    V = dObsU_M[-1]
+    ax  = fig.add_subplot(223)
+    ax.set_aspect('equal')
+    v   = V.compute_vertex_values(mesh)
+    minv = np.min(v)
+    maxv = np.max(v)
+    levels = np.linspace(minv,maxv,numlev)
+    ticks = np.linspace(minv,maxv,3)
+    ax.tick_params(**tick_options)
+    ax.text(0.05, 0.95, 'a', transform=ax.transAxes,
+    fontsize=13, fontweight='bold', va='top')
+    c = ax.tricontourf(x, y, t, v, levels = levels, cmap=plt.get_cmap(cmap_div))
+    cbar = plt.colorbar(c, ticks=ticks, pad=0.05)
+
+    V = dObsV_M[-1]
+    ax  = fig.add_subplot(224)
+    ax.set_aspect('equal')
+    v   = V.compute_vertex_values(mesh)
+    minv = np.min(v)
+    maxv = np.max(v)
+    levels = np.linspace(minv,maxv,numlev)
+    ticks = np.linspace(minv,maxv,3)
+    ax.tick_params(**tick_options)
+    ax.text(0.05, 0.95, 'a', transform=ax.transAxes,
+    fontsize=13, fontweight='bold', va='top')
+    c = ax.tricontourf(x, y, t, v, levels = levels, cmap=plt.get_cmap(cmap_div))
+    cbar = plt.colorbar(c, ticks=ticks, pad=0.05)
+
+
+    plt.show()
+#    cbar.ax.set_xlabel(r'$U_{obs}$ (m $yr^{-1}$)')
                
     # Look at the last sampled time and check how sigma QoI converges
     # with addition of more eigenvectors

--- a/runs/run_obs_sens_prop.py
+++ b/runs/run_obs_sens_prop.py
@@ -15,15 +15,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from fenics_ice.backend import Function, HDF5File, project
-from tlm_adjoint import reset_manager, set_manager, stop_manager, \
-        configure_tlm, function_tlm, restore_manager,\
+from fenics_ice.backend import Function, HDF5File
+from tlm_adjoint import set_manager, stop_manager, \
+        configure_tlm, function_tlm, restore_manager, \
         EquationManager, start_manager
 
 import os
-from mpi4py import MPI
-os.environ["OMP_NUM_THREADS"] = "1"
-os.environ["OPENBLAS_NUM_THREADS"] = "1"
 
 import mpi4py.MPI as MPI  # noqa: N817
 from pathlib import Path
@@ -32,7 +29,6 @@ import numpy as np
 import sys
 
 from fenics_ice import model, solver, inout
-from fenics_ice.model import interp_weights, interpolate
 from fenics_ice import mesh as fice_mesh
 from fenics_ice.config import ConfigParser
 from ufl import split
@@ -40,8 +36,11 @@ from fenics_ice.solver import Amat_obs_action
 
 import matplotlib as mpl
 mpl.use("Agg")
-import matplotlib.pyplot as plt
 from scipy.sparse import spdiags
+
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+
 
 # the function below is not in run_errorprop.py, but needed for obs sens
 @restore_manager
@@ -99,12 +98,8 @@ def run_obs_sens_prop(config_file):
     mdl.beta_from_inversion()
     mdl.bglen_from_data(mask_only=True)
 
-
     # Setup our solver object -- obs_sensitivity flag set to ensure caching
     slvr = solver.ssa_solver(mdl, mixed_space=params.inversion.dual, obs_sensitivity=True)
-
-    # from errorprop -- this variable is not used in that fn
-    #cntrl = slvr.get_control()[0]
 
     cntrl = slvr.get_control()
     space = slvr.get_control_space()

--- a/runs/run_obs_sens_prop.py
+++ b/runs/run_obs_sens_prop.py
@@ -224,7 +224,7 @@ def run_obs_sens_prop(config_file):
         # this block of code then implements A.tau
         # but it needs to be made negative..
 
-        # note -- added mult by -1 because im not sure i had before, can be taken out
+        # note -- added mult by -1 before, but this was found to be incorrect
         dobsu = Amat_obs_action(P, Ru, tauu, interp_space)
         dobsv = Amat_obs_action(P, Rv, tauv, interp_space)
 

--- a/runs/run_obs_sens_prop.py
+++ b/runs/run_obs_sens_prop.py
@@ -223,8 +223,8 @@ def run_obs_sens_prop(config_file):
         # but it needs to be made negative..
 
         # note -- added mult by -1 because im not sure i had before, can be taken out
-        dobsu = -1.0*Amat_obs_action(P, Ru, tauu, interp_space)
-        dobsv = -1.0*Amat_obs_action(P, Rv, tauv, interp_space)
+        dobsu = Amat_obs_action(P, Ru, tauu, interp_space)
+        dobsv = Amat_obs_action(P, Rv, tauv, interp_space)
 
         # this end result (above) corresponds only to the velocity obs
         # that live on this processor's subdomain. An MPI reduce

--- a/runs/run_obs_sens_prop.py
+++ b/runs/run_obs_sens_prop.py
@@ -253,6 +253,11 @@ def run_obs_sens_prop(config_file):
         dobsu = Amat_obs_action(P, Ru, tauu, interp_space)
         dobsv = Amat_obs_action(P, Rv, tauv, interp_space)
 
+        # this end result (above) corresponds only to the velocity obs
+        # that live on this processor's subdomain. An MPI reduce
+        # is used to generate the global vectors, which are then 
+        # saved with numpy.save()
+            
         sendbuf = np.zeros(len(mdl.vel_obs['u_obs']),dtype='float')
         rcvbuf = None
         if rank == 0:

--- a/runs/run_obs_sens_prop.py
+++ b/runs/run_obs_sens_prop.py
@@ -177,13 +177,6 @@ def run_obs_sens_prop(config_file):
     dObsU = []
     dObsV = []
     
-    # the following definitions are purely for visualisation
-    #M_coords = mdl.M.tabulate_dof_coordinates()
-    #vtx_M, wts_M = interp_weights(mdl.vel_obs['uv_obs_pts'],
-    #                              M_coords, params.mesh.periodic_bc)
-    #dObsU_M = []
-    #dObsV_M = []
-
     comm = MPI.COMM_WORLD
     size = comm.Get_size()
     rank = comm.Get_rank()
@@ -216,35 +209,12 @@ def run_obs_sens_prop(config_file):
         P3.vector()[:] = P2.vector()[:] - P1.vector()[:]
         
 
-        # retaining the following code causes a tlm_adjoint runtime error in the 2nd execution of the loop 
-        #  so the code is packaged within a decorated function
-        # reset_manager()
-        # stop_manager(tlm=False)
-        # configure_tlm((cntrl, P3))
-        # slvr.forward(cntrl)
-        # tau = function_tlm(slvr.U, (cntrl, P3))
-
         # tau is  d(U,V)/dm * (Gamma_{prior} - W D W^T) * (dQ/dm), or
         #         d(U,V)/dm * P3
         tau = compute_tau(slvr.forward, slvr.U, cntrl, P3)
 
         # tau is in the space of U (right?)
         tauu, tauv = split(tau)
-
-        #tauuQ = project(tauu,mdl.Q)
-        #tauvQ = project(tauv,mdl.Q)
-
-        #if ( j==(num_sens-1) ):
-        # x    = mesh.coordinates()[:,0]
-        # y    = mesh.coordinates()[:,1]
-        # t    = mesh.cells()
-        # cmap_div='RdBu'
-        # V = tauvQ
-        # v   = V.compute_vertex_values(mesh)
-        # plt.tricontourf(x, y, t, v, cmap=plt.get_cmap(cmap_div))
-        # plt.show()
-
-
 
 
         # this block of code then implements A.tau
@@ -276,69 +246,6 @@ def run_obs_sens_prop(config_file):
         dObsU.append(dobsU)
         dObsV.append(dobsV)
 
-        # this iqs simply interpolation for later visualisation
-        # this could be a point of error.. but I don't know
-        # how to test this by visualising dObsU, dObsV!
-        #dObsU_M.append(Function(mdl.M, static=True))
-        #dObsV_M.append(Function(mdl.M, static=True))
-        #dObsU_M[j].vector()[:] = interpolate(dobsu, vtx_M, wts_M)
-        #dObsV_M[j].vector()[:] = interpolate(dobsv, vtx_M, wts_M)
-
-
-
-
-# below is some plotting commands, will not be used her but in another script
-    
-#    V = mdl.u_obs_M
-#    ax  = fig.add_subplot(221)
-#    ax.set_aspect('equal')
-#    v   = V.compute_vertex_values(mesh)
-#    ticks = np.linspace(10,30,3)
-#    c = ax.tricontourf(x, y, t, v, cmap=plt.get_cmap(cmap_div))
-#    cbar = plt.colorbar(c, ticks=ticks, pad=0.05)
-#
-#    V = mdl.v_obs_M
-#    ax  = fig.add_subplot(222)
-#    ax.set_aspect('equal')
-#    v   = V.compute_vertex_values(mesh)
-#    ticks = np.linspace(10,30,3)
-#    c = ax.tricontourf(x, y, t, v, cmap=plt.get_cmap(cmap_div))
-#    cbar = plt.colorbar(c, ticks=ticks, pad=0.05)
-#
-#    numlev = 20
-#    tick_options = {'axis':'both','which':'both','bottom':False,
-#        'top':False,'left':False,'right':False,'labelleft':False, 'labelbottom':False}
-#
-#    V = dObsU_M[-1]
-#    ax  = fig.add_subplot(223)
-#    ax.set_aspect('equal')
-#    v   = V.compute_vertex_values(mesh)
-#    minv = np.min(v)
-#    maxv = np.max(v)
-#    levels = np.linspace(minv,maxv,numlev)
-#    ticks = np.linspace(minv,maxv,3)
-#    ax.tick_params(**tick_options)
-#    ax.text(0.05, 0.95, 'a', transform=ax.transAxes,
-#    fontsize=13, fontweight='bold', va='top')
-#    c = ax.tricontourf(x, y, t, v, levels = levels, cmap=plt.get_cmap(cmap_div))
-#    cbar = plt.colorbar(c, ticks=ticks, pad=0.05)
-
-#    V = dObsV_M[-1]
-#    ax  = fig.add_subplot(224)
-#    ax.set_aspect('equal')
-#    v   = V.compute_vertex_values(mesh)
-#    minv = np.min(v)
-#    maxv = np.max(v)
-#    levels = np.linspace(minv,maxv,numlev)
-#    ticks = np.linspace(minv,maxv,3)
-#    ax.tick_params(**tick_options)
-#    ax.text(0.05, 0.95, 'a', transform=ax.transAxes,
-#    fontsize=13, fontweight='bold', va='top')
-#    c = ax.tricontourf(x, y, t, v, levels = levels, cmap=plt.get_cmap(cmap_div))
-#    cbar = plt.colorbar(c, ticks=ticks, pad=0.05)
-
-
-               
 
     # Save plots in diagnostics
     phase_sens = params.obs_sens.phase_name
@@ -348,11 +255,6 @@ def run_obs_sens_prop(config_file):
     with open( os.path.join(diag_dir, 'vel_sens.npy'), "wb" ) as sensfile:
         np.save(sensfile, [dObsU, dObsV])
         sensfile.close()
-    #    pickle.dump( [sigma, t_sens], sigfile)
-    #with open( os.path.join(outdir_err, sigma_prior_file), "wb" ) as sigpfile:
-    #    pickle.dump( [sigma_prior, t_sens], sigpfile)
-
-
 
 if __name__ == "__main__":
     assert len(sys.argv) == 2, "Expected a configuration file (*.toml)"


### PR DESCRIPTION
This pull request addresses [issue 120](https://github.com/EdiGlacUQ/fenics_ice/issues/120). 

The main addition is a new `runs/run_obs_sens_prop.py` script, which is intended to be called after run_eigendec.py. As of now, it has only been called with simple example cases, and the script `example_cases/ismipc_30x30/ismipc_30x30.sh` has been modified to call this script. Note that up to line 154, this script is almost exactly like  `runs/errorprop.py`, which has been thoroughly checked. At this point, the script ends by producing a figure using `plt.show()` -- this is not meant to be permanent of course!

`fenics_ice/solver.py` was modified as well, primarily to add the function `Amat_obs_action`, which provides the action of $\mathbf{A}$ from [issue 120](https://github.com/EdiGlacUQ/fenics_ice/issues/120). 

The only changes to `fenics_ice/model.py` were to enable visualisation of the results by making use of the `interp_weights` and `interpolate` functions from `model.py`. This might not be the best way to visualise, and it needs to be checked whether this visualisation is the reason for the strange results!

As of now, the way to run is to navigate to example_cases/ismipc_30x30 and type

bash ismipc_30x30.sh

in subsequent runs, it is necessary only to write

python $FENICS_ICE_BASE_DIR/runs/run_obs_sens_prop.py ismipc_30x30.toml

there are also a few "from IPython import embed" statements that need to be removed. `mpl.use("Agg")` in `runs/run_obs_sens_prop.py` needs to be uncommented. The visualisation plotting should likely be replaced by saving of the raw sensitivities, visualisation to be in a plotting script.

**UPDATE** I have pushed some changes to the branch. The correct way to test this functionality is to navigate to 

example_cases/ismipc_30x30
bash ismipc_30x30.sh

**TODO** create plotting file in aux to visualise ismipc results
