### PR TITLE
revert ismip_30x30 toml back to pre-sept 2023

### DIFF
--- a/example_cases/ismipc_30x30/ismipc_30x30.toml
+++ b/example_cases/ismipc_30x30/ismipc_30x30.toml
@@ -128,10 +128,6 @@ qoi = 'h2' #or 'vaf'
     name = "Bottom Edge"
     id = 4
 
-[mass_solve]
-
-use_cg_thickness = true
-
 [testing]
 
 expected_init_alpha = 531.6114524861194

--- a/example_cases/ismipc_30x30/ismipc_30x30.toml
+++ b/example_cases/ismipc_30x30/ismipc_30x30.toml
@@ -32,7 +32,7 @@ random_seed = 0
 [mesh]
 
 mesh_filename = "ismip_mesh.xml"
-periodic_bc = false
+periodic_bc = true
 
 [obs]
 
@@ -67,8 +67,7 @@ sliding_law = 'linear' #budd, linear
 [momsolve.picard_params]
 nonlinear_solver = "newton"
 [momsolve.picard_params.newton_solver]
-linear_solver = "cg"
-preconditioner = "hypre_amg"
+linear_solver = "umfpack"
 maximum_iterations = 200
 absolute_tolerance = 1.0e-0
 relative_tolerance = 1.0e-3
@@ -78,9 +77,7 @@ error_on_nonconvergence =  false
 [momsolve.newton_params]
 nonlinear_solver = "newton"
 [momsolve.newton_params.newton_solver]
-#linear_solver = "umfpack"
-linear_solver = "cg"
-preconditioner = "hypre_amg"
+linear_solver = "umfpack"
 maximum_iterations = 25
 absolute_tolerance = 1.0e-7
 relative_tolerance = 1.0e-8


### PR DESCRIPTION
PR [126](https://github.com/EdiGlacUQ/fenics_ice/pull/126) introduced unintended changes to ismip_30x30.toml. This PR reverts these changes to its previous version. All github-action tests pass (with some warnings) on bow.