### PR TITLE
VAF masking

### DIFF
--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -266,6 +266,7 @@ class ErrorPropCfg(ConfigPrinter):
     """
     qoi: str = 'vaf'
     qoi_apply_vaf_mask: bool = False
+    qoi_mask: str = ''
     phase_name: str = 'error_prop'
     phase_suffix: str = ''
 

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -265,6 +265,8 @@ class ErrorPropCfg(ConfigPrinter):
     Configuration related to error propagation
     """
     qoi: str = 'vaf'
+    qoi_apply_vaf_mask: bool = False
+    qoi_mask: str = ''
     phase_name: str = 'error_prop'
     phase_suffix: str = ''
 
@@ -487,6 +489,7 @@ class IOCfg(ConfigPrinter):
     alpha_data_file: str = None
     melt_depth_therm_data_file: str = None
     melt_max_data_file: str = None
+    vaf_mask_data_file: str = None
 
     thick_field_name: str = "thick"
     bed_field_name: str = "bed"
@@ -498,6 +501,7 @@ class IOCfg(ConfigPrinter):
     alpha_field_name: str = "alpha"
     melt_depth_therm_field_name: str = "melt_depth"
     melt_max_field_name: str = "melt_max"
+    vaf_mask_field_name: str = "vaf_mask"
 
     inversion_file: str = None
     qoi_file: str = None  # "Qval_ts.p"

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -266,7 +266,6 @@ class ErrorPropCfg(ConfigPrinter):
     """
     qoi: str = 'vaf'
     qoi_apply_vaf_mask: bool = False
-    qoi_mask: str = ''
     phase_name: str = 'error_prop'
     phase_suffix: str = ''
 

--- a/fenics_ice/inout.py
+++ b/fenics_ice/inout.py
@@ -497,7 +497,7 @@ class InputData(object):
 
         # List of fields to search for
         field_list = ["thick", "bed", "bmelt", "smb", "Bglen", "Bglenmask", "alpha", \
-                      "melt_depth_therm", "melt_max"]
+                      "melt_depth_therm", "melt_max", "vaf_mask"]
 
         # Dictionary of filenames & field names (i.e. field to get from HDF5 file)
         # Possibly equal to None for variables which have sensible defaults

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -162,8 +162,8 @@ class model:
 
         if self.params.melt.use_melt_parameterisation:
        
-         melt_depth_therm_const: float = -999.0
-         melt_max_const: float = -999.0
+         #melt_depth_therm_const: float = -999.0
+         #melt_max_const: float = -999.0
 
          if (self.params.melt.melt_depth_therm_const == -999.0 or \
           self.params.melt.melt_max_const == -999.0):
@@ -176,6 +176,9 @@ class model:
          self.melt_depth_therm = self.field_from_data("melt_depth_therm", self.M2, default=melt_depth, \
           method='nearest')
          self.melt_max = self.field_from_data("melt_max", self.M2, default=melt_max, method='nearest')
+
+        if self.params.errorprop.qoi_apply_vaf_mask:
+         self.vaf_mask = self.field_from_data("vaf_mask", self.M2, default=1.0, method='nearest')
 
         self.H = self.H_np.copy(deepcopy=True)
         self.H.rename("thick_H", "")

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -177,7 +177,7 @@ class model:
           method='nearest')
          self.melt_max = self.field_from_data("melt_max", self.M2, default=melt_max, method='nearest')
 
-        if self.params.errorprop.qoi_apply_vaf_mask:
+        if self.params.error_prop.qoi_apply_vaf_mask:
          self.vaf_mask = self.field_from_data("vaf_mask", self.M2, default=1.0, method='nearest')
 
         self.H = self.H_np.copy(deepcopy=True)

--- a/fenics_ice/model.py
+++ b/fenics_ice/model.py
@@ -161,9 +161,6 @@ class model:
          self.H_np = self.field_from_data("thick", self.M, min_val=min_thick)
 
         if self.params.melt.use_melt_parameterisation:
-       
-         #melt_depth_therm_const: float = -999.0
-         #melt_max_const: float = -999.0
 
          if (self.params.melt.melt_depth_therm_const == -999.0 or \
           self.params.melt.melt_max_const == -999.0):

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -130,6 +130,8 @@ class ssa_solver:
         if self.params.melt.use_melt_parameterisation:
          self.melt_depth_therm = model.melt_depth_therm
          self.melt_max = model.melt_max
+        if self.params.errorprop.qoi_apply_vaf_mask:
+         self.vaf_mask = model.vaf_mask
 
         self.set_inv_params()
 
@@ -1454,8 +1456,12 @@ class ssa_solver:
 
         b_ex = conditional(bed < 0.0, 1.0, 0.0)
         HAF = ufl.Max(b_ex * (H + (rhow/rhoi)*bed) + (1-b_ex)*(H), 0.0)
-
-        Q_vaf = HAF * dx
+   
+        if self.params.errorprop.qoi_apply_vaf_mask:
+         msk_ex = conditional(self.vaf_mask > 0.0, 1.0, 0.0)
+         Q_vaf = msk_ex * HAF * dx
+        else:
+         Q_vaf = HAF * dx
 
         if verbose:
             info(f"Q_vaf: {assemble(Q_vaf)}")

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -130,7 +130,7 @@ class ssa_solver:
         if self.params.melt.use_melt_parameterisation:
          self.melt_depth_therm = model.melt_depth_therm
          self.melt_max = model.melt_max
-        if self.params.errorprop.qoi_apply_vaf_mask:
+        if self.params.error_prop.qoi_apply_vaf_mask:
          self.vaf_mask = model.vaf_mask
 
         self.set_inv_params()
@@ -1457,7 +1457,7 @@ class ssa_solver:
         b_ex = conditional(bed < 0.0, 1.0, 0.0)
         HAF = ufl.Max(b_ex * (H + (rhow/rhoi)*bed) + (1-b_ex)*(H), 0.0)
    
-        if self.params.errorprop.qoi_apply_vaf_mask:
+        if self.params.error_prop.qoi_apply_vaf_mask:
          msk_ex = conditional(self.vaf_mask > 0.0, 1.0, 0.0)
          Q_vaf = msk_ex * HAF * dx
         else:


### PR DESCRIPTION
This P/R introduces a way to mask the VAF calculation done in solver.comp_Q_vaf() by introducing a logical mask.

The mask (variable vaf_mask) can be applied by setting:  

- params.error_prop.qoi_apply_vaf_mask = True
- params.io.vaf_mask_data_file to a netcdf file

the netcdf file must have x and y coordinates and the mask variable should be zero where the VAF should not be calculated and greater than zero (e.g. 1) where VAF is to be calculated, and should have a variable name given by params.io.vaf_mask_field_name (default "vaf_mask")