### PR TITLE
new change to have multiple mask values

### DIFF
--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -267,7 +267,7 @@ class ErrorPropCfg(ConfigPrinter):
     qoi: str = 'vaf'
     qoi_apply_vaf_mask: bool = False
     qoi_vaf_mask_usecode: bool = False
-    qoi_vaf_mask_code: int = -1
+    qoi_vaf_mask_code: int = 1
     phase_name: str = 'error_prop'
     phase_suffix: str = ''
 

--- a/fenics_ice/config.py
+++ b/fenics_ice/config.py
@@ -266,6 +266,8 @@ class ErrorPropCfg(ConfigPrinter):
     """
     qoi: str = 'vaf'
     qoi_apply_vaf_mask: bool = False
+    qoi_vaf_mask_usecode: bool = False
+    qoi_vaf_mask_code: int = -1
     phase_name: str = 'error_prop'
     phase_suffix: str = ''
 

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -1460,7 +1460,7 @@ class ssa_solver:
         if self.params.error_prop.qoi_apply_vaf_mask:
             if self.params.error_prop.qoi_vaf_mask_usecode:
                 code = float(self.params.error_prop.qoi_vaf_mask_code)
-                msk_ex = conditional((self.vaf_mask-code)<1.e-10, 1.0, 0.0)
+                msk_ex = conditional(abs(self.vaf_mask-code)<1.e-10, 1.0, 0.0)
             else:
                 msk_ex = conditional(self.vaf_mask > 0.0, 1.0, 0.0)
             Q_vaf = msk_ex * HAF * dx

--- a/fenics_ice/solver.py
+++ b/fenics_ice/solver.py
@@ -1458,10 +1458,14 @@ class ssa_solver:
         HAF = ufl.Max(b_ex * (H + (rhow/rhoi)*bed) + (1-b_ex)*(H), 0.0)
    
         if self.params.error_prop.qoi_apply_vaf_mask:
-         msk_ex = conditional(self.vaf_mask > 0.0, 1.0, 0.0)
-         Q_vaf = msk_ex * HAF * dx
+            if self.params.error_prop.qoi_vaf_mask_usecode:
+                code = float(self.params.error_prop.qoi_vaf_mask_code)
+                msk_ex = conditional((self.vaf_mask-code)<1.e-10, 1.0, 0.0)
+            else:
+                msk_ex = conditional(self.vaf_mask > 0.0, 1.0, 0.0)
+            Q_vaf = msk_ex * HAF * dx
         else:
-         Q_vaf = HAF * dx
+            Q_vaf = HAF * dx
 
         if verbose:
             info(f"Q_vaf: {assemble(Q_vaf)}")


### PR DESCRIPTION
this builds on [PR 133](https://github.com/EdiGlacUQ/fenics_ice/pull/133) which has now been merged.

according to 133, a mask is provided which is either zero or larger than zero.

this new functionality allows a mask with multiple (positive) integer values, and a run only calculates VAF where the mask is equal to a given integer code. 

the code is set via "qoi_vaf_mask_code" (integer, default 1)
and if "qoi_vaf_mask_usecode" is True, this functionality is used -- otherwise the default functionality, that VAF is calculated where the mask if positive.

the appropriate section of the toml file will be as follows:

```
[io]
..
vaf_mask_data_file = ...  # variable in netcdf file needs name "vaf_mask"

..

[errorprop]

qoi = 'vaf'
phase_suffix = ...
qoi_apply_vaf_mask = true       # this should be set to true to enable masking
qoi_vaf_mask_usecode = true  # if set to true, then VAF is calculated only in region of vaf_mask_data_file 
                             # where vaf_mask is equal to qoi_vaf_mask_code
                             # if set to false (default), then VAF is calculated in region of 
                             # vaf_mask_data_file where vaf_mask > 0
qoi_vaf_mask_code = 3       
```
